### PR TITLE
Fix: transferred profiles do not expire

### DIFF
--- a/src/components/request/Grid.tsx
+++ b/src/components/request/Grid.tsx
@@ -59,7 +59,7 @@ const normalize = (
           old: Number(chainId) === legacyChain.id,
           chainId: Number(chainId) as SupportedChainId,
           expired:
-            (request.status.id === "resolved" || request.status.id === "transferred") && 
+            (request.status.id === "resolved") && 
             request.humanity.winnerClaim.length>0 && 
             !!humanityLifespan && 
             request.humanity.winnerClaim[0].index === request.index && // Is this the winner request

--- a/src/data/humanity.ts
+++ b/src/data/humanity.ts
@@ -35,7 +35,9 @@ export const getHumanityData = cache(async (pohId: Hash) => {
     out[chain.id].humanity?.requests.filter(req => {
       return (req.status.id === 'resolved' && 
       out[chain.id].humanity?.winnerClaim.at(0)?.index === req.index && 
-      !(out[chain.id].humanity?.requests.find(reqG => reqG.index > req.index))
+      !(out[chain.id].humanity?.requests.find(reqG => reqG.index > req.index)) && 
+      out[chain.id].crossChainRegistration &&
+      out[chain.id].outTransfer
       )
     }).forEach(req => req.status.id = "transferred");
   })

--- a/src/data/request.ts
+++ b/src/data/request.ts
@@ -5,7 +5,6 @@ import { sdk } from "config/subgraph";
 import { RequestsQuery } from "generated/graphql";
 import { Address, Hash, concat, keccak256, toHex } from "viem";
 import axios from "axios";
-import { getContractDataAllChains } from "./contract";
 
 const _getAllRequests = async () => {
   const res = await Promise.all(
@@ -28,13 +27,7 @@ export const getRequestsInitData = async () => {
 export const checkDataIntegrity = async (filtered: Record<SupportedChainId, RequestsQuery["requests"]> | undefined) => {
   var all: Record<SupportedChainId, RequestsQuery["requests"]> = await _getAllRequests(); 
   var out: Record<SupportedChainId, RequestsQuery["requests"]> = filtered? filtered : all; 
-  
-  var humanityLifespanAllChains: Partial<Record<SupportedChainId, string>> = {};
-  const [contractData] = await Promise.all([getContractDataAllChains()]);
-  Object.keys(contractData).map(
-    (chainId) => humanityLifespanAllChains[Number(chainId) as SupportedChainId] = contractData[Number(chainId) as SupportedChainId].humanityLifespan
-  );
-  
+    
   supportedChains.forEach(chain => {
     const incompleteRequests = out[chain.id].length>0 && out[chain.id].filter(req => 
       (!req.evidenceGroup || !req.evidenceGroup.evidence || req.evidenceGroup.evidence.length === 0 || !req.claimer.name)
@@ -54,7 +47,6 @@ export const checkDataIntegrity = async (filtered: Record<SupportedChainId, Requ
       })
     }
   
-    const humanityLifespan = humanityLifespanAllChains[chain.id]
     const transferred = out[chain.id].filter(req => 
       !req.humanity.registration && 
       req.status.id === 'resolved' && 
@@ -62,7 +54,6 @@ export const checkDataIntegrity = async (filtered: Record<SupportedChainId, Requ
     );
     if (transferred) {
       transferred.map(req => {
-        if ((Number(req.humanity.winnerClaim.at(0)?.resolutionTime) + Number(humanityLifespan) < Date.now() / 1000)) return req.status.id = "resolved" // expired
         if (Number(req.humanity.nbRequests)>Number(req.index)+1) return req.status.id = "resolved"
         return req.status.id = "transferred"
       });


### PR DESCRIPTION
The claiming request on the original chain for a profile that has being transferred, turns from resolved into transferred and since its personhood does not hold in the chain, there is no expired status for such a request.