### PR TITLE
Fixes

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,6 +1,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
+      MAINNET_RPC: string;
       GNOSIS_RPC: string;
       CHIADO_RPC: string;
       SEPOLIA_RPC: string;

--- a/schemas/request.gql
+++ b/schemas/request.gql
@@ -18,6 +18,7 @@ query Request($id: ID!) {
       nbRequests
       nbLegacyRequests
       registration {
+        expirationTime
         claimer {
           id
         }

--- a/schemas/requests.gql
+++ b/schemas/requests.gql
@@ -23,6 +23,7 @@ query Requests($skip: Int, $first: Int, $where: Request_filter) {
       id
       nbRequests
       registration {
+        expirationTime
         claimer {
           id
         }

--- a/src/app/[pohid]/claim/Form.tsx
+++ b/src/app/[pohid]/claim/Form.tsx
@@ -218,6 +218,7 @@ export default withClientConnected<FormProps & JSX.IntrinsicAttributes>(
               <VideoStep
                 advance={() => step$.set(Step.review)}
                 video$={media$.video}
+                isRenewal={!!renewal}
               />
             ),
             [Step.review]: () => (

--- a/src/app/[pohid]/claim/Video.tsx
+++ b/src/app/[pohid]/claim/Video.tsx
@@ -3,7 +3,7 @@ import React, { useRef, useState } from "react";
 import ReactWebcam from "react-webcam";
 import Uploader from "components/Uploader";
 import Webcam from "components/Webcam";
-import { IS_IOS } from "utils/media";
+import { IS_IOS, OS } from "utils/media";
 import useFullscreen from "hooks/useFullscreen";
 import { useAccount } from "wagmi";
 import { ObservableObject } from "@legendapp/state";
@@ -17,9 +17,10 @@ const MIN_DIMS = { width: 352, height: 352 };
 interface PhotoProps {
   advance: () => void;
   video$: ObservableObject<MediaState["video"]>;
+  isRenewal: boolean;
 }
 
-function VideoStep({ advance, video$ }: PhotoProps) {
+function VideoStep({ advance, video$, isRenewal }: PhotoProps) {
   const video = video$.use();
 
   const { address } = useAccount();
@@ -35,7 +36,6 @@ function VideoStep({ advance, video$ }: PhotoProps) {
   const [recorder, setRecorder] = useState<MediaRecorder | null>(null);
 
   const startRecording = () => {
-    console.log(recorder, recording);
     if (!camera || !camera.stream) return;
     const mediaRecorder = new MediaRecorder(camera.stream, {
       mimeType: IS_IOS ? "video/mp4" : "video/webm",
@@ -72,6 +72,19 @@ function VideoStep({ advance, video$ }: PhotoProps) {
     video$.delete();
   };
 
+  const isMac = OS.name?.includes("Mac");
+  const phrase = 
+    isRenewal
+    ? "I certify I am a real human and I reapply to keep being part of this registry"
+    : "I certify that I am a real human and that I am not already registered in this registry";
+
+  const secondaryPhrase = 
+    isMac
+    ? "For MAC computers, momentarily, we recommend recording on a different media and upload afterwards." 
+    : "The phrase will also appear on screen when you start recording."
+  ;
+  
+
   return (
     <>
       <span className="w-full my-4 flex flex-col text-2xl font-semibold">
@@ -88,8 +101,7 @@ function VideoStep({ advance, video$ }: PhotoProps) {
         <span className="my-2">
           <code className="text-theme">"</code>
           <strong>
-            I certify that I am a real human and that I am not already
-            registered in this registry
+            {phrase}
           </strong>
           <code className="text-theme">"</code>
         </span>
@@ -97,7 +109,7 @@ function VideoStep({ advance, video$ }: PhotoProps) {
 
       {showCamera && (
         <span className="text-center mb-4">
-          The phrase will also appear on screen when you start recording.
+          {secondaryPhrase}
         </span>
       )}
 
@@ -154,7 +166,7 @@ function VideoStep({ advance, video$ }: PhotoProps) {
         </div>
       )}
 
-      {showCamera && (
+      {showCamera && !isMac && (
         <div tabIndex={0} ref={fullscreenRef}>
           <Webcam
             isVideo

--- a/src/app/[pohid]/page.tsx
+++ b/src/app/[pohid]/page.tsx
@@ -85,7 +85,12 @@ async function Profile({ params: { pohid } }: PageProps) {
       if (request) {
         requestQuery = humanity[lastEvidenceChain.id]!.humanity!.requests
           .find(req => req.index === request!.index);
-        expired = (Number(requestQuery?.creationTime) + Number(contractData[lastEvidenceChain.id].humanityLifespan) < Date.now() / 1000);
+        expired = (humanity[homeChain.id]!.humanity!.registration!.expirationTime < Date.now() / 1000);
+        /* expired = (
+          (Number(request.resolutionTime) > 0 && 
+          Number(request.resolutionTime) + Number(contractData[lastEvidenceChain.id].humanityLifespan) < Date.now() / 1000) || 
+          (Number(requestQuery?.creationTime) + Number(contractData[lastEvidenceChain.id].humanityLifespan) < Date.now() / 1000)
+        ); */
         if (expired) {
           request = undefined;
         } else {

--- a/src/components/request/Grid.tsx
+++ b/src/components/request/Grid.tsx
@@ -92,8 +92,11 @@ const isRequestExpired = (request: RequestsQueryItem, humanityLifespan: string |
       !!humanityLifespan && 
       request.humanity.winnerClaim[0].index === request.index) { // Is this the winner request
         return (
-          (Number(request.humanity.winnerClaim[0].resolutionTime) + Number(humanityLifespan) < Date.now() / 1000) || 
-          !request.humanity.registration
+          /* (Number(request.humanity.winnerClaim[0].resolutionTime) > 0 && 
+            Number(request.humanity.winnerClaim[0].resolutionTime) + Number(humanityLifespan) < Date.now() / 1000) || 
+          (Number(request.creationTime) + Number(humanityLifespan) < Date.now() / 1000) ||  */
+          !request.humanity.registration || 
+          (Number(request.humanity.registration?.expirationTime) < Date.now() / 1000)
         )
     }// else return (Number(request.creationTime) + Number(humanityLifespan) < Date.now() / 1000)
   } else if (request.status.id === "transferring") {
@@ -179,13 +182,16 @@ function RequestsGrid() {
       humanityLifespanAllChains = Object.keys(contractData).reduce((acc, chainId) => {
         acc[Number(chainId) as SupportedChainId] = contractData[Number(chainId) as SupportedChainId].humanityLifespan;
         return acc;
-      }, {} as Record<SupportedChainId, string>);  
-    })();
+      }, {} as Record<SupportedChainId, string>);
 
-    (async () => {
       chainStacks$.set(await getRequestsInitData());
       loading.stop();
     })();
+
+    /* (async () => {
+      chainStacks$.set(await getRequestsInitData());
+      loading.stop();
+    })(); */
 
     filter$.onChange(
       async ({

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,23 +1,27 @@
-import { gnosis, sepolia, gnosisChiado } from "viem/chains";
+import { mainnet, gnosis, sepolia, gnosisChiado } from "viem/chains";
 
-export const supportedChains = [gnosis, sepolia, gnosisChiado];
+//export const supportedChains = [mainnet, gnosis];
+export const supportedChains = [sepolia, gnosisChiado];
 export const defaultChain = supportedChains[0];
 
 export const legacyChain = sepolia;
-export const vdbChain = sepolia;
-export const tokenChain = gnosis;
+//export const legacyChain = mainnet;
 
 export type SupportedChain = ArrayElement<typeof supportedChains>;
 export type SupportedChainId = SupportedChain["id"];
 
 export function nameToChain(name: string): SupportedChain | null {
   switch (name.toLowerCase()) {
+    /* case mainnet.name.toLowerCase():
+      return mainnet; */
+    /* case gnosis.name.toLowerCase():
+      return gnosis; */
+      //-----------
     case sepolia.name.toLowerCase():
       return sepolia;
-    case gnosis.name.toLowerCase():
-      return gnosis;
     case gnosisChiado.name.toLowerCase().replace(/ /g, '%20'):
       return gnosisChiado;
+      //-----------
     default:
       return null;
     // throw new Error("chain not supported");
@@ -26,12 +30,16 @@ export function nameToChain(name: string): SupportedChain | null {
 
 export function idToChain(id: number): SupportedChain | null {
   switch (id) {
+    /* case mainnet.id:
+      return mainnet; */
+    /* case gnosis.id:
+      return gnosis; */
+      //-----------
     case sepolia.id:
       return sepolia;
-    case gnosis.id:
-      return gnosis;
     case gnosisChiado.id:
       return gnosisChiado;
+      //-----------
     default:
       return null;
     // throw new Error("chain not supported");
@@ -49,12 +57,16 @@ export function paramToChain(param: string): SupportedChain | null {
 
 export function getChainRpc(id: number): string {
   switch (id) {
+    /* case mainnet.id:
+      return process.env.MAINNET_RPC; */
+    /* case gnosis.id:
+      return process.env.GNOSIS_RPC; */
+      //-----------
     case sepolia.id:
       return process.env.SEPOLIA_RPC;
-    case gnosis.id:
-      return process.env.GNOSIS_RPC;
     case gnosisChiado.id:
       return process.env.CHIADO_RPC;
+      //-----------
     default:
       throw new Error("chain not supported");
   }
@@ -63,12 +75,16 @@ export function getChainRpc(id: number): string {
 
 export function getForeignChain(chainId: number) {
   switch (chainId) {
+    //-----------
     case 10200:
       return 11155111;
     case 11155111:
       return 10200;
+    //-----------
+    /* case 1:
+      return 100;
     case 100:
-      return 100; // For launching this will map to mainnet's id
+      return 1; */
     default:
       throw new Error("chain not supported");
   }

--- a/src/config/subgraph.ts
+++ b/src/config/subgraph.ts
@@ -1,7 +1,8 @@
 import { getSdk } from "generated/graphql";
 import { GraphQLClient } from "graphql-request";
-import { gnosis, sepolia, gnosisChiado } from "viem/chains";
+import { gnosis, sepolia, gnosisChiado, mainnet } from "viem/chains";
 import { SupportedChainId } from "./chains";
+import { configSet } from "contracts";
 
 export type sdkReturnType = ReturnType<typeof getSdk>;
 export type queryType = keyof sdkReturnType;
@@ -11,20 +12,33 @@ export type queryReturnType<Q extends queryType> = Record<
 >;
 
 export const sdk = {
-  [sepolia.id]: getSdk(
+  /* [mainnet.id]: getSdk(
     new GraphQLClient(
       "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
-      //"https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/v0.0.12"
+      //"https://api.studio.thegraph.com/query/64099/proof-of-humanity-mainnet/version/latest"
     )
-  ),
+  ), */
   [gnosis.id]: getSdk(
     new GraphQLClient(
       "https://api.studio.thegraph.com/query/64099/proof-of-humanity-gnosis/version/latest"
     )
   ),
+  [sepolia.id]: getSdk(
+    new GraphQLClient(
+      (configSet === "testOld") ? 
+      "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/v0.1.5" // OLD
+      : (configSet === "testNew") ? 
+      "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
+      : ""
+    )
+  ),
   [gnosisChiado.id]: getSdk(
     new GraphQLClient(
-      "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.0/gn"
+      (configSet === "testOld") ? 
+      "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.0/gn" // OLD
+      : (configSet === "testNew") ? 
+      "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.1/gn"
+      : ""
     )
   ),
 };

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,34 +1,44 @@
-import { gnosis, sepolia, gnosisChiado } from "viem/chains";
+import { gnosis, sepolia, gnosisChiado, mainnet } from "viem/chains";
+
+export const configSet: string = 
+  "testOld";
+  //"testNew";
+  //"main";
 
 export const Contract = {
-  ProofOfHumanity: {
-    [sepolia.id]: "0x29defF3DbEf6f79ef20d3fe4f9CFa0547acCeC0D",
+  ProofOfHumanity: 
+  (configSet === "testOld") ? 
+  {
+    [mainnet.id]: "0x29defF3DbEf6f79ef20d3fe4f9CFa0547acCeC0D", // OLD
+    [sepolia.id]: "0x29defF3DbEf6f79ef20d3fe4f9CFa0547acCeC0D", // OLD
+    [gnosisChiado.id]: "0x2505C87AA36d9ed18514Ea7473Ac58aeDeb50849", // OLD
     //[gnosis.id]: "0xB6412c84eC958cafcC80B688d6F473e399be488f",
     [gnosis.id]: "0x4a594f0e73223c9a1CE0EfC16da92fFaA193a612",
-    [gnosisChiado.id]: "0x2505C87AA36d9ed18514Ea7473Ac58aeDeb50849",
-  },
-  CrossChainProofOfHumanity: {
-    [sepolia.id]: "0xd134748B972A320a73EfDe3AfF7a68718F6bA92c",
+  } : (configSet === "testNew")? {
+    [gnosis.id]: "0x4a594f0e73223c9a1CE0EfC16da92fFaA193a612",
+    [mainnet.id]: "0x0D4674De96459e00A101656b799ba016fBc45dC1",
+    [sepolia.id]: "0x0D4674De96459e00A101656b799ba016fBc45dC1",
+    [gnosisChiado.id]: "0x2F0f39c3CF5cffc0DeACEb69d3fD883734D67687",
+  } : {},
+  CrossChainProofOfHumanity:
+  (configSet === "testOld") ? 
+  {
+    [mainnet.id]: "0xd134748B972A320a73EfDe3AfF7a68718F6bA92c", //OLD
+    [sepolia.id]: "0xd134748B972A320a73EfDe3AfF7a68718F6bA92c", //OLD
+    [gnosisChiado.id]: "0xBEd896A3DEa0E065F05Ba83Fa63322c7b9d67838", //OLD
     [gnosis.id]: "0x2C692919Da3B5471F9Ac6ae1C9D1EE54F8111f76",
-    [gnosisChiado.id]: "0xBEd896A3DEa0E065F05Ba83Fa63322c7b9d67838",
-  },
+  } : (configSet === "testNew")? {
+    [gnosis.id]: "0x2C692919Da3B5471F9Ac6ae1C9D1EE54F8111f76",
+    [mainnet.id]: "0xDb7070C1AE12f83E709FF22c4c51993a570FDF84", 
+    [sepolia.id]: "0xDb7070C1AE12f83E709FF22c4c51993a570FDF84",
+    [gnosisChiado.id]: "0x2f33051DF37Edf2286E3b2B3c7883E1A13D82071",
+  } : {},
   Multicall3: {
+    [mainnet.id]: mainnet.contracts.multicall3.address,
     [sepolia.id]: sepolia.contracts.multicall3.address,
     [gnosis.id]: gnosis.contracts.multicall3.address,
     [gnosisChiado.id]: gnosisChiado.contracts.multicall3.address,
   },
-  // GroupCurrencyToken: {
-  //   [sepolia.id]: "0x0000000000000000000000000000000000000000",
-  //   [gnosis.id]: "0x0000000000000000000000000000000000000000",
-  // },
-  // CirclesHub: {
-  //   [sepolia.id]: "0x0000000000000000000000000000000000000000",
-  //   [gnosis.id]: "0x0000000000000000000000000000000000000000",
-  // },
-  // PoHGroupCurrencyManager: {
-  //   [sepolia.id]: "0x0000000000000000000000000000000000000000",
-  //   [gnosis.id]: "0x0000000000000000000000000000000000000000",
-  // },
 } as const;
 
 export type ContractName = keyof typeof Contract;

--- a/src/data/sanitizer.ts
+++ b/src/data/sanitizer.ts
@@ -108,7 +108,7 @@ export const getTransferringRequest = (
 ): {homeChainId: SupportedChainId, transferringRequest: RequestQuery['request']} | undefined => {
   if (!request) return ;
   let transferredNumber: number;
-  if (request.index<0) { 
+  if (request.index <= -100) { 
     transferredNumber = -100-request.index;
   } else {
     var orderedBridgedRequests = out[chainId].humanity?.requests
@@ -121,7 +121,7 @@ export const getTransferringRequest = (
   var transferringRequest: any | undefined;
   let homeChainId: SupportedChainId = getForeignChain(chainId);
   var orderedTransferringRequests: any | undefined = out[homeChainId].humanity?.requests
-    .filter(req => (req.status.id == "transferred"))
+    .filter(req => (req.status.id == "transferred" || req.status.id == "transferring"))
     .sort((req1, req2) => req1.creationTime - req2.creationTime);
 
   if (orderedTransferringRequests && orderedTransferringRequests.length > 0) {
@@ -141,7 +141,7 @@ export const getTransferringRequest = (
 
   }
   if (!transferringRequest) return getTransferringRequest(out, homeChainId, request as RequestQuery['request']);
-  if (transferringRequest!.index<0) return getTransferringRequest(out, homeChainId, transferringRequest as RequestQuery['request']);
+  if (transferringRequest!.index<=-100) return getTransferringRequest(out, homeChainId, transferringRequest as RequestQuery['request']);
   
   return {homeChainId, transferringRequest};
 };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -3371,7 +3371,7 @@ export type RequestQueryVariables = Exact<{
 }>;
 
 
-export type RequestQuery = { __typename?: 'Query', request?: { __typename?: 'Request', index: any, revocation: boolean, requester: any, creationTime: any, lastStatusChange: any, status: { __typename?: 'Status', id: string }, vouches: Array<{ __typename?: 'VouchInProcess', voucher: { __typename?: 'Humanity', id: any } }>, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, nbLegacyRequests: any, registration?: { __typename?: 'Registration', claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, claimer: { __typename?: 'Claimer', id: any, name?: string | null, vouchesReceived: Array<{ __typename?: 'Vouch', from: { __typename?: 'Claimer', id: any, registration?: { __typename?: 'Registration', expirationTime: any, humanity: { __typename?: 'Humanity', vouching: boolean } } | null }, humanity: { __typename?: 'Humanity', id: any } }>, vouches: Array<{ __typename?: 'Vouch', for: { __typename?: 'Claimer', id: any, name?: string | null } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', id: any, uri: string, creationTime: any, submitter: any }> }, challenges: Array<{ __typename?: 'Challenge', id: any, disputeId: any, nbRounds: any, reason: { __typename?: 'Reason', id: string }, challenger?: { __typename?: 'Challenger', id: any } | null, rounds: Array<{ __typename?: 'Round', requesterFund: { __typename?: 'RequesterFund', amount: any }, challengerFund?: { __typename?: 'ChallengerFund', amount: any } | null }> }>, arbitratorHistory: { __typename?: 'ArbitratorHistory', updateTime: any, registrationMeta: string } } | null };
+export type RequestQuery = { __typename?: 'Query', request?: { __typename?: 'Request', index: any, revocation: boolean, requester: any, creationTime: any, lastStatusChange: any, status: { __typename?: 'Status', id: string }, vouches: Array<{ __typename?: 'VouchInProcess', voucher: { __typename?: 'Humanity', id: any } }>, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, nbLegacyRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, claimer: { __typename?: 'Claimer', id: any, name?: string | null, vouchesReceived: Array<{ __typename?: 'Vouch', from: { __typename?: 'Claimer', id: any, registration?: { __typename?: 'Registration', expirationTime: any, humanity: { __typename?: 'Humanity', vouching: boolean } } | null }, humanity: { __typename?: 'Humanity', id: any } }>, vouches: Array<{ __typename?: 'Vouch', for: { __typename?: 'Claimer', id: any, name?: string | null } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', id: any, uri: string, creationTime: any, submitter: any }> }, challenges: Array<{ __typename?: 'Challenge', id: any, disputeId: any, nbRounds: any, reason: { __typename?: 'Reason', id: string }, challenger?: { __typename?: 'Challenger', id: any } | null, rounds: Array<{ __typename?: 'Round', requesterFund: { __typename?: 'RequesterFund', amount: any }, challengerFund?: { __typename?: 'ChallengerFund', amount: any } | null }> }>, arbitratorHistory: { __typename?: 'ArbitratorHistory', updateTime: any, registrationMeta: string } } | null };
 
 export type RequestsQueryVariables = Exact<{
   skip?: InputMaybe<Scalars['Int']>;
@@ -3380,7 +3380,7 @@ export type RequestsQueryVariables = Exact<{
 }>;
 
 
-export type RequestsQuery = { __typename?: 'Query', requests: Array<{ __typename?: 'Request', id: any, index: any, revocation: boolean, creationTime: any, lastStatusChange: any, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, registration?: { __typename?: 'Registration', claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> };
+export type RequestsQuery = { __typename?: 'Query', requests: Array<{ __typename?: 'Request', id: any, index: any, revocation: boolean, creationTime: any, lastStatusChange: any, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> };
 
 export type IsSyncedQueryVariables = Exact<{
   block: Scalars['Int'];
@@ -3583,6 +3583,7 @@ export const RequestDocument = gql`
       nbRequests
       nbLegacyRequests
       registration {
+        expirationTime
         claimer {
           id
         }
@@ -3673,6 +3674,7 @@ export const RequestsDocument = gql`
       id
       nbRequests
       registration {
+        expirationTime
         claimer {
           id
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,6 +3101,11 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@remix-run/router@1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.17.0.tgz#fbb0add487478ef42247d5942e7a5d8a2e20095f"
+  integrity sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw==
+
 "@repeaterjs/repeater@3.0.4", "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -9735,6 +9740,21 @@ react-native-fetch-api@^3.0.0:
   integrity sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==
   dependencies:
     p-defer "^3.0.0"
+
+react-router-dom@^6.24.0:
+  version "6.24.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.24.0.tgz#ec49dc38c49bb9bd25b310a8ae849268d3085e1d"
+  integrity sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==
+  dependencies:
+    "@remix-run/router" "1.17.0"
+    react-router "6.24.0"
+
+react-router@6.24.0:
+  version "6.24.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.24.0.tgz#aa46648f26b6525e07f908ad3e1ad2e68d131155"
+  integrity sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==
+  dependencies:
+    "@remix-run/router" "1.17.0"
 
 react-select@^5.7.7:
   version "5.8.0"


### PR DESCRIPTION
Expiration of requests: modified gql queries

According to registration policy, text on registration is slightly different from the one on renewal

Tooltip explaining the phrase "policy in force at submission"

For testing purposes, configSet allows to change between two different sets of contracts and subgraphs from Sepolia and Chiado

Fix on Sanitizer for findinfg transferringRequest when the request is registered on the legacy-PoHv1