### PR TITLE
Upgraded subgraph and fixes

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,6 @@
 overwrite: true
-schema: "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
+#schema: "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
+schema: "https://api.studio.thegraph.com/query/64099/proof-of-humanity-mainnet/version/latest"
 documents: "schemas/**/*.gql"
 generates:
   ./src/generated/graphql.ts:

--- a/schemas/humanity.gql
+++ b/schemas/humanity.gql
@@ -20,10 +20,14 @@ query Humanity($id: ID!) {
       lastStatusChange
       index
       revocation
+      registrationEvidenceRevokedReq
       requester
       evidenceGroup {
         evidence(orderBy: creationTime, first: 1) {
+          id
           uri
+          creationTime
+          submitter
         }
       }
     }

--- a/schemas/request.gql
+++ b/schemas/request.gql
@@ -5,6 +5,7 @@ query Request($id: ID!) {
     }
     index
     revocation
+    registrationEvidenceRevokedReq
     requester
     creationTime
     lastStatusChange

--- a/schemas/requests.gql
+++ b/schemas/requests.gql
@@ -12,6 +12,7 @@ query Requests($skip: Int, $first: Int, $where: Request_filter) {
       id
     }
     revocation
+    registrationEvidenceRevokedReq
     creationTime
     lastStatusChange
     requester

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -31,7 +31,12 @@ export default withClientConnected<HeaderProps>(function Header({ policy }) {
 
   return (
     // <header className="px-8 pb-2 sm:pt-2 w-full flex justify-between items-center text-white text-lg gradient shadow-sm">
-    <header className="px-6 md:px-8 pb-2 sm:pt-2 w-full grid grid-cols-2 md:grid-cols-[200px_minmax(100px,_1fr)_minmax(100px,300px)] text-white text-lg gradient shadow-sm">
+    <header 
+      className="
+        px-6 md:px-8 pb-2 sm:pt-2 w-full
+        grid grid-cols-2 md:grid-cols-[200px_minmax(100px,_1fr)_minmax(100px,300px)]
+        text-white text-lg gradient shadow-sm"
+    >
       <Link href="/" className="flex items-center w-[156px]">
         <Image
           alt="proof of humanity logo"
@@ -40,7 +45,6 @@ export default withClientConnected<HeaderProps>(function Header({ policy }) {
           width={156}
         />
       </Link>
-
       <div className="my-2 sm:place-self-end grid grid-cols-2 sm:flex gap-x-8 sm:gap-x-12 whitespace-nowrap">
         {web3Loaded && chain.id === sepolia.id && (
           <ExternalLink href="https://docs.scroll.io/en/user-guide/faucet/">
@@ -124,14 +128,14 @@ export default withClientConnected<HeaderProps>(function Header({ policy }) {
             <ExternalLink href="https://gov.proofofhumanity.id/">
               Forums
             </ExternalLink>
+            <ExternalLink href="https://t.me/pohDebug">
+              Report Bugs (Telegram)
+            </ExternalLink>
             <ExternalLink href="https://github.com/Proof-Of-Humanity/proof-of-humanity-web/issues">
-              Report a bug
+              Report Bugs (Github)
             </ExternalLink>
             <ExternalLink href="https://kleros.gitbook.io/docs/products/proof-of-humanity/proof-of-humanity-tutorial">
               Tutorial
-            </ExternalLink>
-            <ExternalLink href="https://t.me/pohDebug">
-              Report a bug
             </ExternalLink>
             <ExternalLink href="https://ethereum.org/en/wallets">
               Crypto Beginner's Guide

--- a/src/app/[pohid]/CrossChain.tsx
+++ b/src/app/[pohid]/CrossChain.tsx
@@ -93,12 +93,12 @@ export default withClientConnected<CrossChainProps>(function CrossChain({
     senderChain: lastTransferChain,
     receivingChain: supportedChains.find(
       (chain) =>
-        Contract.CrossChainProofOfHumanity[chain.id].toLowerCase() ===
+        Contract.CrossChainProofOfHumanity[chain.id]?.toLowerCase() ===
         lastTransfer?.foreignProxy
     )!,
     received: !!supportedChains.find(
       (c) => 
-        Contract.CrossChainProofOfHumanity[c.id].toLowerCase() === 
+        Contract.CrossChainProofOfHumanity[c.id]?.toLowerCase() === 
         lastTransfer?.foreignProxy
     ),
   });
@@ -193,7 +193,7 @@ export default withClientConnected<CrossChainProps>(function CrossChain({
                             gateway.foreignProxy ===
                             Contract.CrossChainProofOfHumanity[
                               chain.id
-                            ].toLowerCase()
+                            ]?.toLowerCase()
                         );
 
                         if (!gatewayForChain) return;

--- a/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
+++ b/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
@@ -440,7 +440,7 @@ export default withClientConnected<ActionBarProps>(function ActionBar({
           </>
         )}
 
-        {index === -1 && (
+        {(index < 0 && index > -100) && (
           <span>
             Check submission on
             <ExternalLink

--- a/src/app/[pohid]/[chain]/[request]/Vouch.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Vouch.tsx
@@ -68,7 +68,7 @@ export default function Vouch({ pohId, claimer }: VouchButtonProps) {
       domain: {
         name: "Proof of Humanity",
         chainId: chain.id,
-        verifyingContract: Contract.ProofOfHumanity[chain.id],
+        verifyingContract: Contract.ProofOfHumanity[chain.id] as any,
       },
       types: {
         IsHumanVoucher: [

--- a/src/app/[pohid]/[chain]/[request]/page.tsx
+++ b/src/app/[pohid]/[chain]/[request]/page.tsx
@@ -99,10 +99,14 @@ export default async function Request({ params }: PageProps) {
 
   if (request.revocation) {
     const [registrationEvidence, revocationEvidence] = await Promise.all([
+      !!request.registrationEvidenceRevokedReq?
+        ipfsFetch<EvidenceFile>(request.registrationEvidenceRevokedReq)
+      : 
       (request.humanity.winnerClaim.length>0 && request.humanity.winnerClaim.at(0)!.evidenceGroup.evidence.length>0)?
-      ipfsFetch<EvidenceFile>(
-        request.humanity.winnerClaim.at(0)!.evidenceGroup.evidence.at(-1)!.uri
-      ): null,
+        ipfsFetch<EvidenceFile>(
+          request.humanity.winnerClaim.at(0)!.evidenceGroup.evidence.at(-1)!.uri
+        )
+      : null,
       ipfsFetch<EvidenceFile>(request.evidenceGroup.evidence.at(-1)!.uri),
     ]);
 
@@ -240,7 +244,7 @@ export default async function Request({ params }: PageProps) {
               <div className="flex justify-between">
                 Revocation requested - {revocationFile.name}
                 {revocationFile.fileURI && (
-                  <Attachment uri="revocationFile.fileURI" />
+                  <Attachment uri={revocationFile.fileURI} />
                 )}
               </div>
               <p className="text-slate-600">{revocationFile.description}</p>

--- a/src/app/[pohid]/page.tsx
+++ b/src/app/[pohid]/page.tsx
@@ -143,7 +143,7 @@ async function Profile({ params: { pohid } }: PageProps) {
     
     let iTransfArr = findAllIndex(requests, (req) => req!.status.id === "transferred");
     for(let i = 0; i < iTransfArr.length; i++) {
-      if (iTransfArr[i] >= 1) { // We leave the first as it is, since in that case, the bridged profile is winner claim
+      if (iTransfArr[i] >= 0) {
         let iReceived = iTransfArr[i]+1;
         // A transferred request is set to transferred after the receiving request is created, so we need to swap their order 
         if (requests[iReceived]) [requests[iTransfArr[i]], requests[iReceived]] = [requests[iReceived], requests[iTransfArr[i]]];
@@ -328,6 +328,7 @@ async function Profile({ params: { pohid } }: PageProps) {
                     humanity[homeChain.id]!.humanity!.registration!.claimer.id
                   }
                   revocation={false}
+                  registrationEvidenceRevokedReq={""}
                   status={winnerClaimData.status as string}
                   expired={false}
                 />
@@ -364,6 +365,7 @@ async function Profile({ params: { pohid } }: PageProps) {
                   index={req.index}
                   requester={req.requester}
                   revocation={req.revocation}
+                  registrationEvidenceRevokedReq={req.registrationEvidenceRevokedReq}
                   status={req.status.id}
                   expired={req.expired}
                 />
@@ -392,6 +394,7 @@ async function Profile({ params: { pohid } }: PageProps) {
                 index={req.index}
                 requester={req.requester}
                 revocation={req.revocation}
+                registrationEvidenceRevokedReq={req.registrationEvidenceRevokedReq}
                 status={req.status.id}
                 expired={req.expired}
               />

--- a/src/app/api/vouch/[chain]/add/route.ts
+++ b/src/app/api/vouch/[chain]/add/route.ts
@@ -16,7 +16,7 @@ import {
 const getProofOfHumanity = (chain: SupportedChain) =>
   getContract({
     abi: abis.ProofOfHumanity,
-    address: Contract.ProofOfHumanity[chain.id],
+    address: Contract.ProofOfHumanity[chain.id] as `0x${string}`,
     publicClient: createPublicClient({
       chain,
       transport: http(getChainRpc(chain.id)),
@@ -66,7 +66,7 @@ export async function POST(
       domain: {
         name: "Proof of Humanity",
         chainId: chain.id,
-        verifyingContract: Contract.ProofOfHumanity[chain.id],
+        verifyingContract: Contract.ProofOfHumanity[chain.id] as `0x${string}`,
       },
       types: {
         IsHumanVoucher: [

--- a/src/app/api/vouch/[chain]/for-request/[claimer]/[pohid]/route.ts
+++ b/src/app/api/vouch/[chain]/for-request/[claimer]/[pohid]/route.ts
@@ -10,6 +10,7 @@ interface RequestParams {
   pohid: Hash;
 }
 
+export const dynamic = "force-dynamic";
 export async function GET(
   _request: NextRequest,
   { params }: { params: RequestParams }

--- a/src/components/high-order/withClientConnected.tsx
+++ b/src/components/high-order/withClientConnected.tsx
@@ -9,7 +9,7 @@ import { supportedChains } from "config/chains";
 
 const projectId = "9185f693b1bc3d1d3440300c1559a202";
 
-const { publicClient } = configureChains(supportedChains, [
+const { publicClient } = configureChains(supportedChains as any, [
   w3mProvider({ projectId }),
 ]);
 

--- a/src/components/request/Card.tsx
+++ b/src/components/request/Card.tsx
@@ -20,6 +20,7 @@ import ChainLogo from "components/ChainLogo";
 interface ContentProps {
   chainId: SupportedChainId;
   revocation: boolean;
+  registrationEvidenceRevokedReq: string;
   evidence: RequestsQueryItem["evidenceGroup"]["evidence"];
   claimer: RequestsQueryItem["claimer"];
   requester: Address;
@@ -52,6 +53,7 @@ const ErrorFallback: React.FC<{ claimer?: { name?: string | null } }> = ({
 const Content = ({
   chainId,
   revocation,
+  registrationEvidenceRevokedReq,
   humanity,
   evidence,
   requester,
@@ -59,8 +61,11 @@ const Content = ({
   expired,
 }: ContentProps) => {
   const [evidenceURI] = useIPFS<EvidenceFile>(
-    revocation
-      ? humanity.winnerClaim.at(0)?.evidenceGroup.evidence.at(-1)?.uri
+    revocation?
+      !!registrationEvidenceRevokedReq? 
+        registrationEvidenceRevokedReq
+      : 
+        humanity.winnerClaim.at(0)?.evidenceGroup.evidence.at(-1)?.uri
       : evidence.at(-1)?.uri,
     { suspense: true }
   );
@@ -95,6 +100,7 @@ const Content = ({
 function Card({
   status,
   revocation,
+  registrationEvidenceRevokedReq,
   index,
   requester,
   chainId,
@@ -139,6 +145,7 @@ function Card({
             humanity={{ id: pohId, winnerClaim }}
             requester={requester}
             revocation={revocation}
+            registrationEvidenceRevokedReq={registrationEvidenceRevokedReq}
             expired={expired}
           />
         </Suspense>

--- a/src/components/request/Grid.tsx
+++ b/src/components/request/Grid.tsx
@@ -345,6 +345,7 @@ function RequestsGrid() {
             claimer={request.claimer}
             status={request.status.id}
             revocation={request.revocation}
+            registrationEvidenceRevokedReq={request.registrationEvidenceRevokedReq}
             evidence={request.evidenceGroup.evidence}
             expired={request.expired}
           />

--- a/src/config/chains.mainnets.ts
+++ b/src/config/chains.mainnets.ts
@@ -1,0 +1,42 @@
+import { mainnet, gnosis } from "viem/chains";
+
+export const supportedChains = [mainnet, gnosis];
+
+export const legacyChain = mainnet;
+
+export type SupportedChain = ArrayElement<typeof supportedChains>;
+
+export function nameToChain(name: string): SupportedChain | null {
+  switch (name.toLowerCase()) {
+    case mainnet.name.toLowerCase():
+      return mainnet;
+    case gnosis.name.toLowerCase():
+      return gnosis;
+    default:
+      return null;
+    // throw new Error("chain not supported");
+  }
+}
+
+export function idToChain(id: number): SupportedChain | null {
+  switch (id) {
+    case mainnet.id:
+      return mainnet;
+    case gnosis.id:
+      return gnosis;
+    default:
+      return null;
+    // throw new Error("chain not supported");
+  }
+}
+
+export function getForeignChain(chainId: number) {
+  switch (chainId) {
+    case 1:
+      return 100;
+    case 100:
+      return 1;
+    default:
+      throw new Error("chain not supported");
+  }
+}

--- a/src/config/chains.testnets.ts
+++ b/src/config/chains.testnets.ts
@@ -1,0 +1,42 @@
+import { sepolia, gnosisChiado } from "viem/chains";
+
+export const supportedChains = [sepolia, gnosisChiado];
+
+export const legacyChain = sepolia;
+
+export type SupportedChain = ArrayElement<typeof supportedChains>;
+
+export function nameToChain(name: string): SupportedChain | null {
+  switch (name.toLowerCase()) {
+    case sepolia.name.toLowerCase():
+      return sepolia;
+    case gnosisChiado.name.toLowerCase().replace(/ /g, '%20'):
+      return gnosisChiado;
+    default:
+      return null;
+    // throw new Error("chain not supported");
+  }
+}
+
+export function idToChain(id: number): SupportedChain | null {
+  switch (id) {
+    case sepolia.id:
+      return sepolia;
+    case gnosisChiado.id:
+      return gnosisChiado;
+    default:
+      return null;
+    // throw new Error("chain not supported");
+  }
+}
+
+export function getForeignChain(chainId: number) {
+  switch (chainId) {
+    case 10200:
+      return 11155111;
+    case 11155111:
+      return 10200;
+    default:
+      throw new Error("chain not supported");
+  }
+}

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,91 +1,55 @@
+import { ChainSet, configSetSelection } from "contracts";
 import { mainnet, gnosis, sepolia, gnosisChiado } from "viem/chains";
+import { 
+  supportedChains as supportedChainsMain, 
+  legacyChain as legacyChainMain, 
+  nameToChain as nameToChainMain, 
+  idToChain as idToChainMain,
+  getForeignChain as getForeignChainMain 
+} from "./chains.mainnets";
+import { supportedChains as supportedChainsTest, 
+  legacyChain as legacyChainTest, 
+  nameToChain as nameToChainTest, 
+  idToChain as idToChainTest,
+  getForeignChain as getForeignChainTest 
+} from "./chains.testnets";
 
-//export const supportedChains = [mainnet, gnosis];
-export const supportedChains = [sepolia, gnosisChiado];
+export const supportedChains = (configSetSelection.chainSet === ChainSet.MAINNETS? supportedChainsMain : supportedChainsTest);
 export const defaultChain = supportedChains[0];
 
-export const legacyChain = sepolia;
-//export const legacyChain = mainnet;
+export const legacyChain = (configSetSelection.chainSet === ChainSet.MAINNETS? legacyChainMain : legacyChainTest);
 
 export type SupportedChain = ArrayElement<typeof supportedChains>;
 export type SupportedChainId = SupportedChain["id"];
 
 export function nameToChain(name: string): SupportedChain | null {
-  switch (name.toLowerCase()) {
-    /* case mainnet.name.toLowerCase():
-      return mainnet; */
-    /* case gnosis.name.toLowerCase():
-      return gnosis; */
-      //-----------
-    case sepolia.name.toLowerCase():
-      return sepolia;
-    case gnosisChiado.name.toLowerCase().replace(/ /g, '%20'):
-      return gnosisChiado;
-      //-----------
-    default:
-      return null;
-    // throw new Error("chain not supported");
-  }
+  return (configSetSelection.chainSet === ChainSet.MAINNETS? nameToChainMain(name) : nameToChainTest(name));
 }
 
 export function idToChain(id: number): SupportedChain | null {
-  switch (id) {
-    /* case mainnet.id:
-      return mainnet; */
-    /* case gnosis.id:
-      return gnosis; */
-      //-----------
-    case sepolia.id:
-      return sepolia;
-    case gnosisChiado.id:
-      return gnosisChiado;
-      //-----------
-    default:
-      return null;
-    // throw new Error("chain not supported");
-  }
+  return (configSetSelection.chainSet === ChainSet.MAINNETS? idToChainMain(id) : idToChainTest(id));
 }
 
 export function paramToChain(param: string): SupportedChain | null {
   if (nameToChain(param)) return nameToChain(param);
   else return idToChain(+param);
-  // try {
-  //   return ;
-  // } catch (err) {
-  // }
 }
 
 export function getChainRpc(id: number): string {
   switch (id) {
-    /* case mainnet.id:
-      return process.env.MAINNET_RPC; */
-    /* case gnosis.id:
-      return process.env.GNOSIS_RPC; */
-      //-----------
+    case mainnet.id:
+      return process.env.MAINNET_RPC;
+    case gnosis.id:
+      return process.env.GNOSIS_RPC;
     case sepolia.id:
       return process.env.SEPOLIA_RPC;
     case gnosisChiado.id:
       return process.env.CHIADO_RPC;
-      //-----------
     default:
       throw new Error("chain not supported");
   }
 }
 
-
 export function getForeignChain(chainId: number) {
-  switch (chainId) {
-    //-----------
-    case 10200:
-      return 11155111;
-    case 11155111:
-      return 10200;
-    //-----------
-    /* case 1:
-      return 100;
-    case 100:
-      return 1; */
-    default:
-      throw new Error("chain not supported");
-  }
+  return (configSetSelection.chainSet === ChainSet.MAINNETS? getForeignChainMain(chainId) : getForeignChainTest(chainId));
 }

--- a/src/config/subgraph.ts
+++ b/src/config/subgraph.ts
@@ -2,7 +2,7 @@ import { getSdk } from "generated/graphql";
 import { GraphQLClient } from "graphql-request";
 import { gnosis, sepolia, gnosisChiado, mainnet } from "viem/chains";
 import { SupportedChainId } from "./chains";
-import { configSet } from "contracts";
+import { configSetSelection, configSets } from "contracts";
 
 export type sdkReturnType = ReturnType<typeof getSdk>;
 export type queryType = keyof sdkReturnType;
@@ -14,10 +14,7 @@ export type queryReturnType<Q extends queryType> = Record<
 export const sdk = {
   [mainnet.id]: getSdk(
     new GraphQLClient(
-      //"https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
-      //"https://api.studio.thegraph.com/query/64099/proof-of-humanity-mainnet/version/latest"
-      "https://api.studio.thegraph.com/query/64099/poh/v0.0.20" // ONLY PoHv1 (Last version)
-      //"https://api.studio.thegraph.com/query/64099/poh/v0.0.19" // ONLY PoHv1 (OLD)
+      "https://api.studio.thegraph.com/query/64099/proof-of-humanity-mainnet/version/latest"
     )
   ),
   [gnosis.id]: getSdk(
@@ -27,18 +24,20 @@ export const sdk = {
   ),
   [sepolia.id]: getSdk(
     new GraphQLClient(
-      (configSet === "testOld") ? 
-      "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/v0.1.5" // OLD
-      : (configSet === "testNew") ? 
+      (configSetSelection.id === configSets.testOld.id) ? 
+      "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia-test/version/latest" // OLD
+      //"https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/v0.1.5" // OLD
+      : (configSetSelection.id === configSets.testNew.id) ? 
       "https://api.studio.thegraph.com/query/64099/proof-of-humanity-sepolia/version/latest"
       : ""
     )
   ),
   [gnosisChiado.id]: getSdk(
     new GraphQLClient(
-      (configSet === "testOld") ? 
-      "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.0/gn" // OLD
-      : (configSet === "testNew") ? 
+      (configSetSelection.id === configSets.testOld.id) ? 
+      "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.2/gn" // OLD
+      //"https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.0/gn" // OLD
+      : (configSetSelection.id === configSets.testNew.id) ? 
       "https://api.goldsky.com/api/public/project_cluh21be5gq0o01u27olk4rwl/subgraphs/proof-of-humanity-chiado/1.0.1/gn"
       : ""
     )

--- a/src/contracts/hooks/useWagmiRead.ts
+++ b/src/contracts/hooks/useWagmiRead.ts
@@ -11,7 +11,7 @@ export default function useWagmiRead<
 >(contract: C, functionName: F, args?: ReadArgs<C, F>) {
   const chainId = useChainId() as SupportedChainId;
   const { data, isLoading, isError, isSuccess } = useContractRead({
-    address: Contract[contract][chainId],
+    address: Contract[contract][chainId] as `0x${string}`,
     abi: abis[contract] as Abi,
     functionName: functionName as string,
     args: args as unknown[],

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,36 +1,50 @@
 import { gnosis, sepolia, gnosisChiado, mainnet } from "viem/chains";
 
-export const configSet: string = 
-  "testOld";
-  //"testNew";
-  //"main";
+export enum ChainSet {
+  MAINNETS,
+  TESTNETS
+}
+
+export const configSets = {
+  'main': {chainSet: ChainSet.MAINNETS, chainSetId: 'main', id: '1'},
+  'testOld': {chainSet: ChainSet.TESTNETS, chainSetId: 'testOld', id: '2'},
+  'testNew': {chainSet: ChainSet.TESTNETS, chainSetId: 'testNew', id: '3'}
+};
+
+export const configSetSelection = configSets.testOld;
 
 export const Contract = {
   ProofOfHumanity: 
-  (configSet === "testOld") ? 
+  (configSetSelection.id === configSets.testOld.id) ? 
   {
     [mainnet.id]: "0x29defF3DbEf6f79ef20d3fe4f9CFa0547acCeC0D", // OLD
     [sepolia.id]: "0x29defF3DbEf6f79ef20d3fe4f9CFa0547acCeC0D", // OLD
     [gnosisChiado.id]: "0x2505C87AA36d9ed18514Ea7473Ac58aeDeb50849", // OLD
     [gnosis.id]: "0x4a594f0e73223c9a1CE0EfC16da92fFaA193a612",
-  } : (configSet === "testNew")? {
+  } : (configSetSelection.id === configSets.testNew.id)? {
     [gnosis.id]: "0x4a594f0e73223c9a1CE0EfC16da92fFaA193a612",
     [mainnet.id]: "0x0D4674De96459e00A101656b799ba016fBc45dC1",
     [sepolia.id]: "0x0D4674De96459e00A101656b799ba016fBc45dC1",
     [gnosisChiado.id]: "0x2F0f39c3CF5cffc0DeACEb69d3fD883734D67687",
+  } : (configSetSelection.id === configSets.main.id)? {
+    [gnosis.id]: "0xe6573F65efAbc351b69F9b73ed8e95772698938b",
+    [mainnet.id]: "0x6cbEdC1920090EA4F28A38C1CD61c8D37b2cc323",
   } : {},
   CrossChainProofOfHumanity:
-  (configSet === "testOld") ? 
+  (configSetSelection.id === configSets.testOld.id) ? 
   {
     [mainnet.id]: "0xd134748B972A320a73EfDe3AfF7a68718F6bA92c", //OLD
     [sepolia.id]: "0xd134748B972A320a73EfDe3AfF7a68718F6bA92c", //OLD
     [gnosisChiado.id]: "0xBEd896A3DEa0E065F05Ba83Fa63322c7b9d67838", //OLD
     [gnosis.id]: "0x2C692919Da3B5471F9Ac6ae1C9D1EE54F8111f76",
-  } : (configSet === "testNew")? {
+  } : (configSetSelection.id === configSets.testNew.id)? {
     [gnosis.id]: "0x2C692919Da3B5471F9Ac6ae1C9D1EE54F8111f76",
     [mainnet.id]: "0xDb7070C1AE12f83E709FF22c4c51993a570FDF84", 
     [sepolia.id]: "0xDb7070C1AE12f83E709FF22c4c51993a570FDF84",
     [gnosisChiado.id]: "0x2f33051DF37Edf2286E3b2B3c7883E1A13D82071",
+  } : (configSetSelection.id === configSets.main.id)? {
+    [gnosis.id]: "0x6cbEdC1920090EA4F28A38C1CD61c8D37b2cc323",
+    [mainnet.id]: "0xD6F4E9d906CD7736a83e0AFa7EE9491658B4afA7",
   } : {},
   Multicall3: {
     [mainnet.id]: mainnet.contracts.multicall3.address,

--- a/src/data/request.ts
+++ b/src/data/request.ts
@@ -38,7 +38,7 @@ export const getRequestsInitData = async () => {
 export const getFilteredRequestsInitData = async (filtered: Record<SupportedChainId, RequestsQuery["requests"]> | undefined) => {
   var all: Record<SupportedChainId, RequestsQuery["requests"]> = await _getPagedRequests(); 
   var out: Record<SupportedChainId, RequestsQuery["requests"]> = filtered? filtered : all; 
-  return sanitizeHeadRequests(all, out);
+  return await sanitizeHeadRequests(all, out);
 }
 
 export const genRequestId = (pohId: Hash, index: number) => {
@@ -49,7 +49,7 @@ export const genRequestId = (pohId: Hash, index: number) => {
         ? toHex(index, { size: 32 })
         : index <= -100
         ? concat([
-          toHex(Math.abs(index + 1), { size: 32 }),
+          toHex(Math.abs(index), { size: 32 }),
           toHex("bridged", { size: 7 }),
         ])
         : concat([
@@ -63,7 +63,7 @@ export const genRequestId = (pohId: Hash, index: number) => {
 export const getRequestData = cache(
   async (chainId: SupportedChainId, pohId: Hash, index: number) => {
     const out = (await sdk[chainId]["Request"]({ id: genRequestId(pohId, index) })).request;
-    return sanitizeRequest(out, chainId, pohId);
+    return await sanitizeRequest(out, chainId, pohId);
   }
 )
 

--- a/src/data/user.ts
+++ b/src/data/user.ts
@@ -17,10 +17,10 @@ export const getMyData = async (account: string) => {
       homeChain,
       pohId:
         homeChain &&
-        res[supportedChains.indexOf(homeChain)].claimer!.registration!.id,
+        res[supportedChains.indexOf(homeChain as any)].claimer!.registration!.id,
       currentRequest: requestChain && {
         chain: requestChain,
-        ...res[supportedChains.indexOf(requestChain)].claimer!.currentRequest!,
+        ...res[supportedChains.indexOf(requestChain as any)].claimer!.currentRequest!,
       },
     };
   };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -324,6 +324,7 @@ export enum Challenge_OrderBy {
   RequestIndex = 'request__index',
   RequestLastStatusChange = 'request__lastStatusChange',
   RequestNbChallenges = 'request__nbChallenges',
+  RequestRegistrationEvidenceRevokedReq = 'request__registrationEvidenceRevokedReq',
   RequestRequester = 'request__requester',
   RequestResolutionTime = 'request__resolutionTime',
   RequestRevocation = 'request__revocation',
@@ -553,6 +554,7 @@ export enum Claimer_OrderBy {
   CurrentRequestIndex = 'currentRequest__index',
   CurrentRequestLastStatusChange = 'currentRequest__lastStatusChange',
   CurrentRequestNbChallenges = 'currentRequest__nbChallenges',
+  CurrentRequestRegistrationEvidenceRevokedReq = 'currentRequest__registrationEvidenceRevokedReq',
   CurrentRequestRequester = 'currentRequest__requester',
   CurrentRequestResolutionTime = 'currentRequest__resolutionTime',
   CurrentRequestRevocation = 'currentRequest__revocation',
@@ -919,6 +921,7 @@ export enum EvidenceGroup_OrderBy {
   RequestIndex = 'request__index',
   RequestLastStatusChange = 'request__lastStatusChange',
   RequestNbChallenges = 'request__nbChallenges',
+  RequestRegistrationEvidenceRevokedReq = 'request__registrationEvidenceRevokedReq',
   RequestRequester = 'request__requester',
   RequestResolutionTime = 'request__resolutionTime',
   RequestRevocation = 'request__revocation'
@@ -2027,6 +2030,7 @@ export type Request = {
   index: Scalars['BigInt'];
   lastStatusChange: Scalars['BigInt'];
   nbChallenges: Scalars['BigInt'];
+  registrationEvidenceRevokedReq: Scalars['String'];
   requester: Scalars['Bytes'];
   resolutionTime: Scalars['BigInt'];
   revocation: Scalars['Boolean'];
@@ -2200,6 +2204,26 @@ export type Request_Filter = {
   nbChallenges_not?: InputMaybe<Scalars['BigInt']>;
   nbChallenges_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   or?: InputMaybe<Array<InputMaybe<Request_Filter>>>;
+  registrationEvidenceRevokedReq?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_contains?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_contains_nocase?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_ends_with?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_gt?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_gte?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_in?: InputMaybe<Array<Scalars['String']>>;
+  registrationEvidenceRevokedReq_lt?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_lte?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_contains?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_ends_with?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_in?: InputMaybe<Array<Scalars['String']>>;
+  registrationEvidenceRevokedReq_not_starts_with?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_starts_with?: InputMaybe<Scalars['String']>;
+  registrationEvidenceRevokedReq_starts_with_nocase?: InputMaybe<Scalars['String']>;
   requester?: InputMaybe<Scalars['Bytes']>;
   requester_contains?: InputMaybe<Scalars['Bytes']>;
   requester_gt?: InputMaybe<Scalars['Bytes']>;
@@ -2321,6 +2345,7 @@ export enum Request_OrderBy {
   Index = 'index',
   LastStatusChange = 'lastStatusChange',
   NbChallenges = 'nbChallenges',
+  RegistrationEvidenceRevokedReq = 'registrationEvidenceRevokedReq',
   Requester = 'requester',
   ResolutionTime = 'resolutionTime',
   Revocation = 'revocation',
@@ -3173,6 +3198,7 @@ export enum VouchInProcess_OrderBy {
   RequestIndex = 'request__index',
   RequestLastStatusChange = 'request__lastStatusChange',
   RequestNbChallenges = 'request__nbChallenges',
+  RequestRegistrationEvidenceRevokedReq = 'request__registrationEvidenceRevokedReq',
   RequestRequester = 'request__requester',
   RequestResolutionTime = 'request__resolutionTime',
   RequestRevocation = 'request__revocation',
@@ -3350,7 +3376,7 @@ export type HumanityQueryVariables = Exact<{
 }>;
 
 
-export type HumanityQuery = { __typename?: 'Query', humanity?: { __typename?: 'Humanity', registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any, name?: string | null } } | null, requests: Array<{ __typename?: 'Request', id: any, creationTime: any, lastStatusChange: any, index: any, revocation: boolean, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }>, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> } | null, crossChainRegistration?: { __typename?: 'CrossChainRegistration', expirationTime: any, lastReceivedTransferTimestamp: any, claimer: { __typename?: 'Claimer', id: any } } | null, outTransfer?: { __typename?: 'OutTransfer', foreignProxy: any, transferHash: any, transferTimestamp: any } | null };
+export type HumanityQuery = { __typename?: 'Query', humanity?: { __typename?: 'Humanity', registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any, name?: string | null } } | null, requests: Array<{ __typename?: 'Request', id: any, creationTime: any, lastStatusChange: any, index: any, revocation: boolean, registrationEvidenceRevokedReq: string, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', id: any, uri: string, creationTime: any, submitter: any }> } }>, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> } | null, crossChainRegistration?: { __typename?: 'CrossChainRegistration', expirationTime: any, lastReceivedTransferTimestamp: any, claimer: { __typename?: 'Claimer', id: any } } | null, outTransfer?: { __typename?: 'OutTransfer', foreignProxy: any, transferHash: any, transferTimestamp: any } | null };
 
 export type MeQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -3371,7 +3397,7 @@ export type RequestQueryVariables = Exact<{
 }>;
 
 
-export type RequestQuery = { __typename?: 'Query', request?: { __typename?: 'Request', index: any, revocation: boolean, requester: any, creationTime: any, lastStatusChange: any, status: { __typename?: 'Status', id: string }, vouches: Array<{ __typename?: 'VouchInProcess', voucher: { __typename?: 'Humanity', id: any } }>, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, nbLegacyRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, claimer: { __typename?: 'Claimer', id: any, name?: string | null, vouchesReceived: Array<{ __typename?: 'Vouch', from: { __typename?: 'Claimer', id: any, registration?: { __typename?: 'Registration', expirationTime: any, humanity: { __typename?: 'Humanity', vouching: boolean } } | null }, humanity: { __typename?: 'Humanity', id: any } }>, vouches: Array<{ __typename?: 'Vouch', for: { __typename?: 'Claimer', id: any, name?: string | null } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', id: any, uri: string, creationTime: any, submitter: any }> }, challenges: Array<{ __typename?: 'Challenge', id: any, disputeId: any, nbRounds: any, reason: { __typename?: 'Reason', id: string }, challenger?: { __typename?: 'Challenger', id: any } | null, rounds: Array<{ __typename?: 'Round', requesterFund: { __typename?: 'RequesterFund', amount: any }, challengerFund?: { __typename?: 'ChallengerFund', amount: any } | null }> }>, arbitratorHistory: { __typename?: 'ArbitratorHistory', updateTime: any, registrationMeta: string } } | null };
+export type RequestQuery = { __typename?: 'Query', request?: { __typename?: 'Request', index: any, revocation: boolean, registrationEvidenceRevokedReq: string, requester: any, creationTime: any, lastStatusChange: any, status: { __typename?: 'Status', id: string }, vouches: Array<{ __typename?: 'VouchInProcess', voucher: { __typename?: 'Humanity', id: any } }>, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, nbLegacyRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, claimer: { __typename?: 'Claimer', id: any, name?: string | null, vouchesReceived: Array<{ __typename?: 'Vouch', from: { __typename?: 'Claimer', id: any, registration?: { __typename?: 'Registration', expirationTime: any, humanity: { __typename?: 'Humanity', vouching: boolean } } | null }, humanity: { __typename?: 'Humanity', id: any } }>, vouches: Array<{ __typename?: 'Vouch', for: { __typename?: 'Claimer', id: any, name?: string | null } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', id: any, uri: string, creationTime: any, submitter: any }> }, challenges: Array<{ __typename?: 'Challenge', id: any, disputeId: any, nbRounds: any, reason: { __typename?: 'Reason', id: string }, challenger?: { __typename?: 'Challenger', id: any } | null, rounds: Array<{ __typename?: 'Round', requesterFund: { __typename?: 'RequesterFund', amount: any }, challengerFund?: { __typename?: 'ChallengerFund', amount: any } | null }> }>, arbitratorHistory: { __typename?: 'ArbitratorHistory', updateTime: any, registrationMeta: string } } | null };
 
 export type RequestsQueryVariables = Exact<{
   skip?: InputMaybe<Scalars['Int']>;
@@ -3380,7 +3406,7 @@ export type RequestsQueryVariables = Exact<{
 }>;
 
 
-export type RequestsQuery = { __typename?: 'Query', requests: Array<{ __typename?: 'Request', id: any, index: any, revocation: boolean, creationTime: any, lastStatusChange: any, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> };
+export type RequestsQuery = { __typename?: 'Query', requests: Array<{ __typename?: 'Request', id: any, index: any, revocation: boolean, registrationEvidenceRevokedReq: string, creationTime: any, lastStatusChange: any, requester: any, status: { __typename?: 'Status', id: string }, claimer: { __typename?: 'Claimer', id: any, name?: string | null }, humanity: { __typename?: 'Humanity', id: any, nbRequests: any, registration?: { __typename?: 'Registration', expirationTime: any, claimer: { __typename?: 'Claimer', id: any } } | null, winnerClaim: Array<{ __typename?: 'Request', index: any, resolutionTime: any, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> }, evidenceGroup: { __typename?: 'EvidenceGroup', evidence: Array<{ __typename?: 'Evidence', uri: string }> } }> };
 
 export type IsSyncedQueryVariables = Exact<{
   block: Scalars['Int'];
@@ -3514,10 +3540,14 @@ export const HumanityDocument = gql`
       lastStatusChange
       index
       revocation
+      registrationEvidenceRevokedReq
       requester
       evidenceGroup {
         evidence(orderBy: creationTime, first: 1) {
+          id
           uri
+          creationTime
+          submitter
         }
       }
     }
@@ -3570,6 +3600,7 @@ export const RequestDocument = gql`
     }
     index
     revocation
+    registrationEvidenceRevokedReq
     requester
     creationTime
     lastStatusChange
@@ -3663,6 +3694,7 @@ export const RequestsDocument = gql`
       id
     }
     revocation
+    registrationEvidenceRevokedReq
     creationTime
     lastStatusChange
     requester


### PR DESCRIPTION
Subgraph revoke requests now refer to the IPFS uri with the registration evidence of the corresponding revoked request (previously several revoke reqs referred to the latest registration which is not accurate)

Easy fixes to frontend

NextJs force-dynamic when getting gasless vouches from supabase

Code refactoring. Development mode with easy configuration for running on TESTNETS or MAINNETS