### PR TITLE
conditional rendering claim btn for pending requests

### DIFF
--- a/src/app/[pohid]/page.tsx
+++ b/src/app/[pohid]/page.tsx
@@ -312,9 +312,11 @@ async function Profile({ params: { pohid } }: PageProps) {
           ) : (
             <>
               <span className="text-orange mb-6">Not claimed</span>
+              {!pendingRequests.length?
               <Link className="btn-main mb-6 w-48" href={`/${pohId}/claim`}>
                 Claim humanity
-              </Link>
+              </Link> : null}
+             
             </>
           )
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the visibility of the "Claim humanity" link by only showing it when no pending requests exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->