### PR TITLE
refactor: temporarily disable App section in navigation and integrations

### DIFF
--- a/src/app/Header/DesktopNavigation.tsx
+++ b/src/app/Header/DesktopNavigation.tsx
@@ -62,12 +62,14 @@ const DesktopNavigation = ({
       >
         Policy
       </Link>
+      {/* Temporarily commented out - App section not displayed in UI
       <Link 
         href="/app" 
         className={`${pathname.startsWith("/app") ? "font-bold" : ""}`}
       >
         App
       </Link>
+      */}
     </div>
   );
 };

--- a/src/app/Header/MobileMenu.tsx
+++ b/src/app/Header/MobileMenu.tsx
@@ -59,9 +59,11 @@ const MobileMenu = forwardRef(
           >
             Policy
           </Link>
+          {/* Temporarily commented out - App section not displayed in UI
           <Link href="/app" className={`${pathname === "/app" ? "font-bold" : ""}`}>
             Apps
           </Link>
+          */}
         </nav>
 
         <div className="mt-4">

--- a/src/app/app/[integrationId]/page.tsx
+++ b/src/app/app/[integrationId]/page.tsx
@@ -31,7 +31,7 @@ export default async function IntegrationPage({
 }: IntegrationPageProps) {
   const integration = await getIntegration(params.integrationId);
   
-  if (!integration) {
+  if (!integration || !integration.isActive) {
     redirect("/app/");
   }
   

--- a/src/data/integrations.ts
+++ b/src/data/integrations.ts
@@ -7,7 +7,7 @@ const integrations: Record<string, Integration> = {
     title: 'Connect your Circles Wallet',
     description: 'Link your Circles address to your POHID and experience trust benefits.',
     logo: '/images/integrations/circles-logo.png',
-    isActive: true,
+    isActive: false, // Temporarily disabled - App section not displayed in UI
     startPath: 'app/circles',
     buttonText: 'Start Now',
     connectionSteps: [


### PR DESCRIPTION
- Commented out App link in both DesktopNavigation and MobileMenu components as it is not displayed in the UI.
- Updated integration status in integrations.ts to false, indicating the App section is temporarily disabled.