### PR TITLE
chore: update GraphQL schema URL in codegen configuration

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "https://api.studio.thegraph.com/query/90401/proof-of-humanity-chiado/version/latest"
+schema: "https://api.studio.thegraph.com/query/61738/poh-origin-gnosis/version/latest"
 documents: "schemas/**/*.gql"
 generates:
   ./src/generated/graphql.ts:


### PR DESCRIPTION
- Changed schema URL to point to the latest version for the Gnosis network.
- Ensured compatibility with the updated GraphQL documents generation.