### PR TITLE
fix: add error logging to useWagmiWrite for prepare status handling

### DIFF
--- a/src/contracts/hooks/useWagmiWrite.ts
+++ b/src/contracts/hooks/useWagmiWrite.ts
@@ -42,7 +42,7 @@ export default function useWagmiWrite<
   
   const [enabled, setEnabled] = useState(false);
 
-  const { data: prepared, status: prepareStatus} = useSimulateContract({
+  const { data: prepared, status: prepareStatus, error: prepareError} = useSimulateContract({
    address: contractInfo.address as `0x${string}`,
     abi: contractInfo.abi as Abi,
     functionName,
@@ -69,6 +69,7 @@ export default function useWagmiWrite<
         break;
       case "error":
         if(enabled){
+          console.error(prepareError);
           effects?.onFail?.();
           setEnabled(false);
         }


### PR DESCRIPTION
- Enhanced useWagmiWrite hook by including error logging for the prepare status.
- Added prepareError to capture and log errors when the contract simulation fails, improving debugging capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of contract interaction flows by detecting and surfacing preparation errors earlier.
  * Prevents repeated attempts after a failed preparation step, reducing noise and confusion.
  * Provides clearer error feedback when a contract action cannot be prepared.

* **Chores**
  * Enhanced internal logging for preparation failures.
  * No changes to public APIs or user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->