### PR TITLE
Fix humanity-revoked handling and optimistic flows

### DIFF
--- a/src/app/[pohid]/CrossChain.tsx
+++ b/src/app/[pohid]/CrossChain.tsx
@@ -29,6 +29,8 @@ import { Address, Hash, createPublicClient, http, decodeEventLog, TransactionRec
 import { mainnet, sepolia, gnosisChiado } from "viem/chains";
 import { useAccount, useChainId, useSwitchChain } from "wagmi";
 import { useRouter } from "next/navigation";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useProfileOptimistic } from "optimistic/profile";
 
 // Define minimal ABI for UserRequestForSignature (Home -> Foreign)
 const USER_REQUEST_FOR_SIGNATURE_ABI = [{
@@ -301,6 +303,9 @@ export default function CrossChain({
   const chainId = useChainId() as SupportedChainId;
   const router = useRouter();
   const { switchChain } = useSwitchChain();
+  const profileOptimistic = useProfileOptimistic();
+  const effectiveWinningStatus =
+    profileOptimistic.effective.winningStatus ?? winningStatus;
   const [isLoading, loadingMessage] = loading.use();
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
@@ -317,14 +322,20 @@ export default function CrossChain({
         onReady(fire) {
           fire();
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            profile: {
+              state: profileOptimistic.effective,
+              applyPatch: profileOptimistic.applyPatch,
+            },
+          });
           toast.success("Transfer initiated!");
           loading.stop();
           setIsTransferModalOpen(false);
           router.refresh();
         },
       }),
-      [loading, router],
+      [loading, router, profileOptimistic],
     ),
   );
   
@@ -338,7 +349,13 @@ export default function CrossChain({
         onReady(fire) {
           fire();
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            profile: {
+              state: profileOptimistic.effective,
+              applyPatch: profileOptimistic.applyPatch,
+            },
+          });
           toast.success("Update transaction sent!");
           loading.stop();
           setTimeout(() => {
@@ -356,7 +373,7 @@ export default function CrossChain({
           loading.stop();
         },
       }),
-      [loading, router],
+      [loading, router, profileOptimistic],
     ),
   );
 
@@ -370,7 +387,13 @@ export default function CrossChain({
         onReady(fire) {
           fire();
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            profile: {
+              state: profileOptimistic.effective,
+              applyPatch: profileOptimistic.applyPatch,
+            },
+          });
           toast.success("Relay transaction sent!");
           loading.stop();
           setTimeout(() => {
@@ -388,7 +411,7 @@ export default function CrossChain({
           loading.stop();
         },
       }),
-      [loading, router],
+      [loading, router, profileOptimistic],
     ),
   );
 
@@ -652,10 +675,13 @@ export default function CrossChain({
 
   useEffect(() => {
     // Only check for pending updates if profile is not in transfer state
-    if (winningStatus !== "transferring" && winningStatus !== "transferred") {
+    if (
+      effectiveWinningStatus !== "transferring" &&
+      effectiveWinningStatus !== "transferred"
+    ) {
       checkPendingUpdate();
     }
-  }, [checkPendingUpdate, winningStatus]);
+  }, [checkPendingUpdate, effectiveWinningStatus]);
 
   return (
     <div className="flex w-full flex-col items-center border-t p-4 sm:flex-row sm:items-center sm:justify-between">
@@ -673,8 +699,9 @@ export default function CrossChain({
       {web3Loaded &&
         address?.toLowerCase() === claimer &&
         homeChain.id === chainId &&
-        winningStatus !== "transferring" &&
-        winningStatus !== "transferred" &&
+        effectiveWinningStatus !== "transferring" &&
+        effectiveWinningStatus !== "transferred" &&
+        !profileOptimistic.effective.pendingTransfer &&
         (
           <Modal
             formal
@@ -714,8 +741,9 @@ export default function CrossChain({
 
       {web3Loaded &&
         homeChain.id === chainId &&
-        winningStatus !== "transferring" &&
-        winningStatus !== "transferred" &&
+        effectiveWinningStatus !== "transferring" &&
+        effectiveWinningStatus !== "transferred" &&
+        !profileOptimistic.effective.pendingUpdate &&
         (!pendingRelayUpdate || !pendingRelayUpdate.encodedData) && (
           <Modal
             formal
@@ -789,7 +817,7 @@ export default function CrossChain({
         //address?.toLowerCase() === claimer &&
         //homeChain?.id === chainId &&
         homeChain &&
-        winningStatus === "transferred" &&
+        effectiveWinningStatus === "transferred" &&
         publicClient && (
           <Modal
             open={isLastTransferModalOpen}
@@ -835,6 +863,16 @@ export default function CrossChain({
             </div>
           </Modal>
         )}
+      {(profileOptimistic.effective.pendingTransfer ||
+        profileOptimistic.effective.pendingUpdate) && (
+        <div className="paper mt-3 p-3">
+          <span className="txt text-secondaryText">
+            {profileOptimistic.effective.pendingTransfer
+              ? "Transfer initiated. Waiting for the profile state to refresh."
+              : "Update initiated. Waiting for the profile state to refresh."}
+          </span>
+        </div>
+      )}
       {!!pendingRelayUpdate && pendingRelayUpdate.encodedData
         ? showPendingUpdate()
         : null}

--- a/src/app/[pohid]/Revoke.tsx
+++ b/src/app/[pohid]/Revoke.tsx
@@ -20,6 +20,9 @@ import { Hash } from "viem";
 import { useChainId, useSwitchChain } from "wagmi";
 import { useAtlasProvider, Roles } from "@kleros/kleros-app";
 import AuthGuard from "components/AuthGuard";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useProfileOptimistic } from "optimistic/profile";
+import { useRouter } from "next/navigation";
 
 enableReactUse();
 
@@ -45,6 +48,11 @@ export default function Revoke({
   const connectedChainId = useChainId() as SupportedChainId;
   const web3Loaded = useWeb3Loaded();
   const { switchChain } = useSwitchChain();
+  const router = useRouter();
+  const profileOptimistic = useProfileOptimistic();
+  const hasPendingRevocation =
+    profileOptimistic.base.hasPendingRevocation ||
+    profileOptimistic.effective.pendingRevocation;
   
   const { uploadFile } = useAtlasProvider();
 
@@ -64,12 +72,19 @@ export default function Revoke({
           loading.stop();
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            profile: {
+              state: profileOptimistic.effective,
+              applyPatch: profileOptimistic.applyPatch,
+            },
+          });
           setModalOpen(false);
           toast.success("Request created");
+          setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [loading],
+      [loading, profileOptimistic, router],
     ),
   );
 
@@ -132,7 +147,11 @@ export default function Revoke({
       open={modalOpen}
       header="Revoke"
       trigger={
-        <button onClick={() => setModalOpen(true)} className="btn-main mb-4">
+        <button
+          onClick={() => setModalOpen(true)}
+          className="btn-main mb-4"
+          disabled={hasPendingRevocation}
+        >
           Revoke
         </button>
       }
@@ -182,13 +201,18 @@ export default function Revoke({
 
         <AuthGuard signInButtonProps={{ className: "mt-12 px-5 py-2" }}>
           <button
-            disabled={pending}
+            disabled={pending || hasPendingRevocation}
             className="btn-main mt-12"
             onClick={submit}
           >
-            Revoke
+            {hasPendingRevocation ? "Pending" : "Revoke"}
           </button>
         </AuthGuard>
+        {hasPendingRevocation && (
+          <span className="text-secondaryText mt-3 text-sm">
+            Revocation request submitted. Waiting for the profile page to refresh.
+          </span>
+        )}
       </div>
     </Modal>
   );

--- a/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
+++ b/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
@@ -24,6 +24,8 @@ import Challenge from "./Challenge";
 import FundButton from "./Funding";
 import RemoveVouch from "./RemoveVouch";
 import Vouch from "./Vouch";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
 
 enableReactUse();
 
@@ -69,19 +71,14 @@ export default function ActionBar({
   requester,
   index,
   revocation,
-  status,
   requestStatus,
-  funded,
   lastStatusChange,
   arbitrationCost,
   contractData,
   currentChallenge,
-  onChainVouches,
-  offChainVouches,
   // advanceRequestsOnChainVouches,
   arbitrationHistory,
   humanityExpirationTime,
-  validVouches,
   usedReasons = [],
 }: ActionBarProps) {
   const chain = useChainParam()!;
@@ -90,48 +87,59 @@ export default function ActionBar({
   const userChainId = useChainId();
   const { data: me } = useSWR(address, getMyData);
   const router = useRouter();
+  const requestOptimistic = useRequestOptimistic();
+  const effectiveStatus = requestOptimistic.effective.status;
+  const effectiveRequestStatus = requestOptimistic.effective.requestStatus;
+  const effectiveFunded = requestOptimistic.effective.funded;
+  const effectiveValidVouches = requestOptimistic.effective.validVouches;
+  const effectiveOnChainVouches = requestOptimistic.effective.onChainVouches;
+  const effectiveOffChainVouches = requestOptimistic.effective.offChainVouches;
+  const pendingChallenge = requestOptimistic.effective.pendingChallenge;
 
   const { didIVouchFor, isVouchOnchain } = useMemo(() => {
     const lowerAddr = address?.toLowerCase();
-    const onChainMatch = onChainVouches.some(
+    const onChainMatch = effectiveOnChainVouches.some(
       (voucherAddress) => voucherAddress.toLowerCase() === lowerAddr,
     );
-    const offChainMatch = offChainVouches.some(
+    const offChainMatch = effectiveOffChainVouches.some(
       (voucher) => voucher.voucher.toLowerCase() === lowerAddr,
     );
     return { didIVouchFor: onChainMatch || offChainMatch, isVouchOnchain: onChainMatch };
-  }, [onChainVouches, offChainVouches, address]);
+  }, [effectiveOnChainVouches, effectiveOffChainVouches, address]);
 
   const action = useMemo(() => {
-    if (status === "resolved" || status === "withdrawn") return ActionType.NONE;
+    if (effectiveStatus === "resolved" || effectiveStatus === "withdrawn")
+      return ActionType.NONE;
     if (index < 0 && index > -100) return ActionType.OLD_ACTIVE;
-    if (status === "disputed") return ActionType.DISPUTED;
-    if (status === "vouching") {
-      if (funded < arbitrationCost + BigInt(contractData.baseDeposit)) return ActionType.FUND;
-      if (validVouches >= contractData.requiredNumberOfVouches) return ActionType.ADVANCE;
+    if (effectiveStatus === "disputed") return ActionType.DISPUTED;
+    if (effectiveStatus === "vouching") {
+      if (effectiveFunded < arbitrationCost + BigInt(contractData.baseDeposit))
+        return ActionType.FUND;
+      if (effectiveValidVouches >= contractData.requiredNumberOfVouches)
+        return ActionType.ADVANCE;
       if (
-        onChainVouches.length + offChainVouches.length >= 0 &&
+        effectiveOnChainVouches.length + effectiveOffChainVouches.length >= 0 &&
         didIVouchFor &&
         isVouchOnchain
       )
         return ActionType.REMOVE_VOUCH;
       return ActionType.VOUCH;
     }
-    if (status == "resolving")
+    if (effectiveStatus == "resolving")
       return +lastStatusChange + +contractData.challengePeriodDuration < Date.now() / 1000
         ? ActionType.EXECUTE
         : ActionType.CHALLENGE;
     return ActionType.NONE;
   }, [
-    status,
+    effectiveStatus,
     index,
-    funded,
+    effectiveFunded,
     arbitrationCost,
     contractData.baseDeposit,
-    validVouches,
+    effectiveValidVouches,
     contractData.requiredNumberOfVouches,
-    onChainVouches,
-    offChainVouches,
+    effectiveOnChainVouches,
+    effectiveOffChainVouches,
     didIVouchFor,
     isVouchOnchain,
     lastStatusChange,
@@ -147,12 +155,19 @@ export default function ActionBar({
         onError() {
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           toast.success("Request executed successfully");
           setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [router],
+      [router, requestOptimistic, address],
     ),
   );
   const [prepareAdvance, advanceFire, advanceStatus] = usePoHWrite(
@@ -162,12 +177,19 @@ export default function ActionBar({
         onError() {
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           toast.success("Request advanced to resolving state");
           setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [router],
+      [router, requestOptimistic, address],
     ),
   );
   const [prepareWithdraw, withdraw, withdrawStatus] = usePoHWrite(
@@ -177,12 +199,19 @@ export default function ActionBar({
         onError() {
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           toast.success("Request withdrawn successfully");
           setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [router],
+      [router, requestOptimistic, address],
     ),
   );
 
@@ -205,8 +234,8 @@ export default function ActionBar({
       prepareAdvance({
         args: [
           requester,
-          onChainVouches,
-          offChainVouches.map((v) => {
+          effectiveOnChainVouches,
+          effectiveOffChainVouches.map((v) => {
             const sig = hexToSignature(v.signature);
             return {
               expirationTime: v.expiration,
@@ -231,6 +260,8 @@ export default function ActionBar({
     chain,
     userChainId,
     canAdvance,
+    effectiveOnChainVouches,
+    effectiveOffChainVouches,
   ]);
 
   useEffect(() => {
@@ -255,7 +286,7 @@ export default function ActionBar({
 
   const totalCost = BigInt(contractData.baseDeposit) + arbitrationCost;
 
-  const statusColor = getStatusColor(requestStatus);
+  const statusColor = getStatusColor(effectiveRequestStatus);
 
   return (
     <div className="paper border-stroke bg-whiteBackground text-primaryText flex flex-col items-center justify-between gap-[12px] px-[24px] py-[24px] md:flex-row lg:gap-[20px]">
@@ -264,7 +295,7 @@ export default function ActionBar({
         <span
           className={`rounded-full px-3 py-1 text-white bg-status-${statusColor} whitespace-nowrap`}
         >
-          {getStatusLabel(requestStatus, 'actionBar')}
+          {getStatusLabel(effectiveRequestStatus, 'actionBar')}
         </span>
       </div>
       <div className="flex w-full flex-col justify-between gap-[12px] font-normal md:flex-row md:items-center">
@@ -275,7 +306,7 @@ export default function ActionBar({
             <>
               <div className="flex justify-center gap-6 md:justify-start">
                 <span className="text-center text-slate-400 md:text-left">
-                  {validVouches < contractData.requiredNumberOfVouches && (
+                  {effectiveValidVouches < contractData.requiredNumberOfVouches && (
                     <>
                       It needs{" "}
                       <strong className={`text-status-${statusColor}`}>
@@ -287,13 +318,13 @@ export default function ActionBar({
                       to proceed
                     </>
                   )}
-                  {!!(totalCost - funded) && (
+                  {!!(totalCost - effectiveFunded) && (
                     <>
-                      {validVouches < contractData.requiredNumberOfVouches
+                      {effectiveValidVouches < contractData.requiredNumberOfVouches
                         ? " + "
                         : "It needs "}
                       <strong className={`text-status-${statusColor}`}>
-                        {formatEther(totalCost - funded)}{" "}
+                        {formatEther(totalCost - effectiveFunded)}{" "}
                         {chain.nativeCurrency.symbol}
                       </strong>{" "}
                       to complete the initial deposit
@@ -313,7 +344,7 @@ export default function ActionBar({
                             BigInt(contractData.baseDeposit) + arbitrationCost
                           }
                           index={index}
-                          funded={funded}
+                          funded={effectiveFunded}
                         />
                       )}
                       <ActionButton
@@ -332,7 +363,7 @@ export default function ActionBar({
                         className="mb-2 w-auto"
                       />
                     </div>
-                    {validVouches < contractData.requiredNumberOfVouches && (
+                    {effectiveValidVouches < contractData.requiredNumberOfVouches && (
                       <ExternalLink
                         href="https://t.me/proofhumanity"
                         className="text-purple hover:opacity-80 underline underline-offset-4 text-sm font-medium inline-flex items-center gap-1 group transition-colors justify-center md:justify-end"
@@ -366,7 +397,7 @@ export default function ActionBar({
                           BigInt(contractData.baseDeposit) + arbitrationCost
                         }
                         index={index}
-                        funded={funded}
+                        funded={effectiveFunded}
                       />
                     )}
                     <Vouch
@@ -387,7 +418,7 @@ export default function ActionBar({
                           BigInt(contractData.baseDeposit) + arbitrationCost
                         }
                         index={index}
-                        funded={funded}
+                        funded={effectiveFunded}
                       />
                     )}
                     <RemoveVouch
@@ -522,7 +553,7 @@ export default function ActionBar({
                 currentChallenge={currentChallenge}
                 chainId={chain.id}
                 revocation={revocation}
-                requestStatus={requestStatus}
+                requestStatus={effectiveRequestStatus}
               />
 
               <ExternalLink
@@ -534,16 +565,21 @@ export default function ActionBar({
             </div>
           </>
         )}
+        {action === ActionType.DISPUTED && !currentChallenge && pendingChallenge && (
+          <span className="text-center text-slate-400 md:text-left">
+            Challenge submitted. Waiting for dispute details to sync.
+          </span>
+        )}
 
-        {status === "resolved" && (
+        {effectiveStatus === "resolved" && (
           <span className="text-center md:text-left">
-            {requestStatus === RequestStatus.EXPIRED ?
+            {effectiveRequestStatus === RequestStatus.EXPIRED ?
               "Request has expired" :
-              requestStatus === RequestStatus.REJECTED ?
+              effectiveRequestStatus === RequestStatus.REJECTED ?
                 "Request was rejected" : "Request was accepted"}
             <TimeAgo
               className={`ml-1 text-status-${statusColor}`}
-              time={requestStatus === RequestStatus.EXPIRED
+              time={effectiveRequestStatus === RequestStatus.EXPIRED
                 ? humanityExpirationTime!
                 : lastStatusChange}
             />

--- a/src/app/[pohid]/[chain]/[request]/Challenge.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Challenge.tsx
@@ -22,6 +22,9 @@ import AuthGuard from "components/AuthGuard";
 import ActionButton from "components/ActionButton";
 import { useChainId } from "wagmi";
 import { idToChain } from "config/chains";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
+import { useRouter } from "next/navigation";
 
 type Reason =
   | "none"
@@ -119,6 +122,8 @@ export default function Challenge({
   const { uploadFile } = useAtlasProvider();
   const chain = useChainParam()!;
   const userChainId = useChainId();
+  const router = useRouter();
+  const requestOptimistic = useRequestOptimistic();
   
   const loading = useLoading();
   const [isLoading, loadingMessage] = loading.use();
@@ -141,12 +146,19 @@ export default function Challenge({
           loading.stop();
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+            },
+          });
           loading.stop();
           toast.success("Challenge submitted successfully");
+          setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [loading],
+      [loading, requestOptimistic, router],
     ),
   );
 

--- a/src/app/[pohid]/[chain]/[request]/Evidence.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Evidence.tsx
@@ -29,9 +29,11 @@ import { shortenAddress } from "utils/address";
 import { ipfsFetch, ipfs } from "utils/ipfs";
 import { romanize } from "utils/misc";
 import { Address, Hash } from "viem";
-import { useChainId } from "wagmi";
+import { useAccount, useChainId } from "wagmi";
 import { useAtlasProvider, Roles } from "@kleros/kleros-app";
 import AuthGuard from "components/AuthGuard";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
 
 enableReactUse();
 
@@ -97,6 +99,7 @@ export default function Evidence({
 }: EvidenceProps) {
   const chainReq = useChainParam()!;
   const chainId = useChainId();
+  const { address } = useAccount();
   const { data: policy } = useSWR(
     arbitrationInfo.registrationMeta,
     async (metaEvidenceLink) =>
@@ -106,6 +109,7 @@ export default function Evidence({
   const loading = useLoading();
   const [pending] = loading.use();
   const router = useRouter();
+  const requestOptimistic = useRequestOptimistic();
 
   const { uploadFile } = useAtlasProvider();
   const [prepare] = usePoHWrite(
@@ -120,14 +124,21 @@ export default function Evidence({
           loading.stop();
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           loading.stop();
           toast.success("Evidence submitted successfully");
           setModalOpen(false);
           router.refresh();
         },
       }),
-      [loading],
+      [loading, router, requestOptimistic, address],
     ),
   );
 
@@ -270,7 +281,7 @@ export default function Evidence({
         </Modal>
       )}
 
-      {list.map((item, i) => (
+      {requestOptimistic.effective.evidenceList.map((item, i) => (
         <Item
           key={item.id}
           index={i}

--- a/src/app/[pohid]/[chain]/[request]/Funding.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Funding.tsx
@@ -11,6 +11,8 @@ import { useRouter } from "next/navigation";
 import { useAccount, useBalance, useChainId } from "wagmi";
 import { formatEth } from "utils/misc";
 import { idToChain } from "config/chains";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
 
 interface FundButtonProps {
   pohId: Hash;
@@ -34,6 +36,7 @@ const FundButton: React.FC<FundButtonProps> = ({
   const { data: balanceData } = useBalance({ address, chainId: userChainId });
   const loading = useLoading();
   const [isLoading, loadingMessage] = loading.use();
+  const requestOptimistic = useRequestOptimistic();
 
   const [prepareFund] = usePoHWrite(
     "fundRequest",
@@ -51,7 +54,14 @@ const FundButton: React.FC<FundButtonProps> = ({
           loading.stop();
           toast.error("Transaction rejected");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           loading.stop();
           setIsModalOpen(false);
           setAddedFundInput("");
@@ -59,7 +69,7 @@ const FundButton: React.FC<FundButtonProps> = ({
           setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [loading, router],
+      [loading, router, requestOptimistic, address],
     ),
   );
 

--- a/src/app/[pohid]/[chain]/[request]/RemoveVouch.tsx
+++ b/src/app/[pohid]/[chain]/[request]/RemoveVouch.tsx
@@ -7,6 +7,10 @@ import { toast } from "react-toastify";
 import { useEffectOnce } from "@legendapp/state/react";
 import { SupportedChain, idToChain } from "config/chains";
 import ActionButton from "components/ActionButton";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
+import { useRouter } from "next/navigation";
+import { useAccount } from "wagmi";
 
 enableReactUse();
 
@@ -30,7 +34,9 @@ export default function RemoveVouch({
   tooltip,
 }: RemoveVouchProps) {
   const loading = useLoading();
-  const [pending] = loading.use();
+  const router = useRouter();
+  const { address } = useAccount();
+  const requestOptimistic = useRequestOptimistic();
 
   const [prepareRemoveVouch, removeOnchainVouch, status] = usePoHWrite(
     "removeVouch",
@@ -43,11 +49,19 @@ export default function RemoveVouch({
           loading.start();
           toast.info("Transaction pending");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           toast.success("Request remove vouch successful");
+          setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [loading],
+      [loading, requestOptimistic, address, router],
     ),
   );
 

--- a/src/app/[pohid]/[chain]/[request]/Vouch.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Vouch.tsx
@@ -10,6 +10,8 @@ import { getContractInfo } from "contracts";
 import { toast } from "react-toastify";
 import { SupportedChain, idToChain } from "config/chains";
 import ActionButton from "components/ActionButton";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
+import { useRequestOptimistic } from "optimistic/request";
 
 interface VouchButtonProps {
   pohId: Hash;
@@ -30,6 +32,7 @@ export default function Vouch({
 }: VouchButtonProps) {
   const router = useRouter();
   const userChainId = useChainId();
+  const requestOptimistic = useRequestOptimistic();
   const [isOpen, setIsOpen] = useState(false);
   const [prepare, addVouch , status] = usePoHWrite(
     "addVouch",
@@ -41,13 +44,20 @@ export default function Vouch({
         onLoading() {
           toast.info("Transaction pending");
         },
-        onSuccess() {
+        onSuccess(ctx) {
+          applyOptimisticWriteSuccess(ctx, {
+            request: {
+              state: requestOptimistic.effective,
+              applyPatch: requestOptimistic.applyPatch,
+              address,
+            },
+          });
           toast.success("Vouched successfully");
           setIsOpen(false);
           setTimeout(() => router.refresh(), 1000);
         },
       }),
-      [],
+      [router, requestOptimistic, address],
     ),
   );
 
@@ -74,6 +84,24 @@ export default function Vouch({
             voucher: address!,
             expiration,
             signature,
+          });
+          const alreadyPresent = requestOptimistic.effective.offChainVouches.some(
+            (item) => item.voucher.toLowerCase() === address?.toLowerCase(),
+          );
+          requestOptimistic.applyPatch({
+            offChainVouches: alreadyPresent
+              ? requestOptimistic.effective.offChainVouches
+              : [
+                  ...requestOptimistic.effective.offChainVouches,
+                  {
+                    voucher: address!,
+                    expiration,
+                    signature,
+                  },
+                ],
+            validVouches: alreadyPresent
+              ? requestOptimistic.effective.validVouches
+              : requestOptimistic.effective.validVouches + 1,
           });
           toast.success("Vouched successfully");
           setIsOpen(false);

--- a/src/app/[pohid]/[chain]/[request]/page.tsx
+++ b/src/app/[pohid]/[chain]/[request]/page.tsx
@@ -39,6 +39,7 @@ import {
 } from "./TimelineSection";
 import DocumentIcon from "components/DocumentIcon";
 import VideoThumbnail from "components/VideoThumbnail";
+import { RequestOptimisticProvider } from "optimistic/request";
 import { getStatus } from "utils/status";
 
 interface PageProps {
@@ -272,37 +273,61 @@ export default async function Request({ params }: PageProps) {
     : null;
 
   //const policyUpdate = request.arbitratorHistory.updateTime;
+  const currentChallenge =
+    request.challenges && request.challenges.length > 0
+      ? request.challenges.at(-1)
+      : undefined;
+  const funded =
+    request.index >= 0
+      ? BigInt(request.challenges[0].rounds[0].requesterFund.amount)
+      : 0n;
+  const evidenceList = request.evidenceGroup.evidence
+    .sort((a, b) => Number(a.creationTime) - Number(b.creationTime))
+    .map((item) => ({
+      id: item.id,
+      uri: item.uri,
+      creationTime: Number(item.creationTime),
+      submitter: item.submitter as Address,
+    }));
 
   return (
-    <div className="content mx-auto flex w-[92vw] sm:w-[84vw] max-w-[1500px] flex-col justify-center font-semibold md:w-[76vw]">
-      <ActionBar
-        arbitrationCost={arbitrationCost}
-        index={request.index}
-        status={request.status.id}
-        requester={request.requester}
-        contractData={contractData}
-        pohId={pohId}
-        lastStatusChange={+request.lastStatusChange}
-        revocation={request.revocation}
-        currentChallenge={
-          request.challenges && request.challenges.length > 0
-            ? request.challenges.at(-1)
-            : undefined
-        }
-        funded={
-          request.index >= 0
-            ? BigInt(request.challenges[0].rounds[0].requesterFund.amount)
-            : 0n
-        }
-        onChainVouches={onChainVouches}
-        offChainVouches={offChainVouches}
-        validVouches={validVouches}
-        arbitrationHistory={request.arbitratorHistory}
-        requestStatus={requestStatus}
-        humanityExpirationTime={request.expirationTime}
-        usedReasons={usedReasons}
-      />
-      <div className="border-stroke bg-whiteBackground mb-6 rounded border shadow">
+    <RequestOptimisticProvider
+      base={{
+        status: request.status.id,
+        requestStatus,
+        funded,
+        totalCost: BigInt(contractData.baseDeposit) + arbitrationCost,
+        validVouches,
+        onChainVouches,
+        offChainVouches,
+        evidenceList,
+        revocation: request.revocation,
+        currentChallengeDisputeId: currentChallenge?.disputeId
+          ? String(currentChallenge.disputeId)
+          : undefined,
+      }}
+    >
+      <div className="content mx-auto flex w-[92vw] sm:w-[84vw] max-w-[1500px] flex-col justify-center font-semibold md:w-[76vw]">
+        <ActionBar
+          arbitrationCost={arbitrationCost}
+          index={request.index}
+          status={request.status.id}
+          requester={request.requester}
+          contractData={contractData}
+          pohId={pohId}
+          lastStatusChange={+request.lastStatusChange}
+          revocation={request.revocation}
+          currentChallenge={currentChallenge}
+          funded={funded}
+          onChainVouches={onChainVouches}
+          offChainVouches={offChainVouches}
+          validVouches={validVouches}
+          arbitrationHistory={request.arbitratorHistory}
+          requestStatus={requestStatus}
+          humanityExpirationTime={request.expirationTime}
+          usedReasons={usedReasons}
+        />
+        <div className="border-stroke bg-whiteBackground mb-6 rounded border shadow">
         {request.revocation && revocationFile && (
           <div className="bg-primaryBackground p-4">
             <div className="relative">
@@ -540,16 +565,17 @@ export default async function Request({ params }: PageProps) {
             </Label>
           </div>
         </div>
-      </div>
+        </div>
 
-      <Evidence
-        list={request.evidenceGroup.evidence.sort(
-          (a, b) => Number(a.creationTime) - Number(b.creationTime),
-        )}
-        pohId={pohId}
-        requestIndex={request.index}
-        arbitrationInfo={request.arbitratorHistory}
-      />
-    </div>
+        <Evidence
+          list={request.evidenceGroup.evidence.sort(
+            (a, b) => Number(a.creationTime) - Number(b.creationTime),
+          )}
+          pohId={pohId}
+          requestIndex={request.index}
+          arbitrationInfo={request.arbitratorHistory}
+        />
+      </div>
+    </RequestOptimisticProvider>
   );
 }

--- a/src/app/[pohid]/claim/Form.tsx
+++ b/src/app/[pohid]/claim/Form.tsx
@@ -31,6 +31,7 @@ import PhotoStep from "./Photo";
 import ReviewStep from "./Review";
 import VideoStep from "./Video";
 import { formatEth } from "utils/misc";
+import { applyOptimisticWriteSuccess } from "optimistic/applyOptimisticWriteSuccess";
 
 enableReactUse();
 
@@ -126,7 +127,8 @@ export default function Form({
       onLoading() {
         toast.info("Transaction pending");
       },
-      onSuccess() {
+      onSuccess(ctx) {
+        applyOptimisticWriteSuccess(ctx, {});
         step$.set(Step.finalized);
         toast.success("Request created");
       },

--- a/src/app/[pohid]/page.tsx
+++ b/src/app/[pohid]/page.tsx
@@ -25,6 +25,7 @@ import Renew from "./Renew";
 import Revoke from "./Revoke";
 import { getStatus, RequestStatus } from "utils/status";
 import { ProfileTimelineSection } from "./TimelineSection";
+import { ProfileOptimisticProvider } from "optimistic/profile";
 
 type PoHRequest = ArrayElement<
   NonNullable<HumanityQuery["humanity"]>["requests"]
@@ -233,6 +234,7 @@ async function Profile({ params: { pohid } }: PageProps) {
         revocation: latestRequest.revocation,
       }
     : undefined;
+  const hasPendingRevocation = activeRequests.some((request) => request.revocation);
 
   return (
     <div className="content">
@@ -329,40 +331,54 @@ async function Profile({ params: { pohid } }: PageProps) {
               </span>
             )}
 
-            <Revoke
-              pohId={pohId}
-              arbitrationInfo={contractData[homeChain.id].arbitrationInfo!}
-              homeChain={homeChain}
-              cost={
-                arbitrationCost + BigInt(contractData[homeChain.id].baseDeposit)
-              }
-            />
+            <ProfileOptimisticProvider
+              base={{
+                winningStatus: winnerClaimData.status,
+                hasPendingRevocation,
+              }}
+            >
+              <Revoke
+                pohId={pohId}
+                arbitrationInfo={contractData[homeChain.id].arbitrationInfo!}
+                homeChain={homeChain}
+                cost={
+                  arbitrationCost + BigInt(contractData[homeChain.id].baseDeposit)
+                }
+              />
+              <CrossChain
+                claimer={
+                  humanity[homeChain.id]!.humanity!.registration!.claimer.id
+                }
+                contractData={contractData}
+                homeChain={homeChain}
+                pohId={pohId}
+                humanity={humanity}
+                lastTransfer={humanity[lastTransferChain.id].outTransfer}
+                lastTransferChain={lastTransferChain}
+                winningStatus={winnerClaimData.status}
+              />
+            </ProfileOptimisticProvider>
+          </>
+        ) : latestTransferArtifact?.status.id === "transferred" ? (
+          <ProfileOptimisticProvider
+            base={{
+              winningStatus: "transferred",
+              hasPendingRevocation: false,
+            }}
+          >
             <CrossChain
               claimer={
-                humanity[homeChain.id]!.humanity!.registration!.claimer.id
+                humanity[lastTransferChain.id]?.humanity!.registration?.claimer.id
               }
               contractData={contractData}
-              homeChain={homeChain}
+              homeChain={idToChain(getForeignChain(lastTransferChain.id))!}
               pohId={pohId}
               humanity={humanity}
               lastTransfer={humanity[lastTransferChain.id].outTransfer}
               lastTransferChain={lastTransferChain}
-              winningStatus={winnerClaimData.status}
+              winningStatus={"transferred"}
             />
-          </>
-        ) : latestTransferArtifact?.status.id === "transferred" ? (
-          <CrossChain
-            claimer={
-              humanity[lastTransferChain.id]?.humanity!.registration?.claimer.id
-            }
-            contractData={contractData}
-            homeChain={idToChain(getForeignChain(lastTransferChain.id))!}
-            pohId={pohId}
-            humanity={humanity}
-            lastTransfer={humanity[lastTransferChain.id].outTransfer}
-            lastTransferChain={lastTransferChain}
-            winningStatus={"transferred"}
-          />
+          </ProfileOptimisticProvider>
         ) : (
           <>
             <span className="text-orange mb-6">Not claimed</span>

--- a/src/app/debug/optimistic/page.tsx
+++ b/src/app/debug/optimistic/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  applyOptimisticWriteSuccess,
+  type OptimisticApi,
+} from "optimistic/applyOptimisticWriteSuccess";
+import {
+  ProfileOptimisticProvider,
+  useProfileOptimistic,
+} from "optimistic/profile";
+import {
+  RequestOptimisticProvider,
+  useRequestOptimistic,
+} from "optimistic/request";
+import type { WriteSuccessContext } from "contracts/hooks/types";
+import { RequestStatus } from "utils/status";
+import type { Address } from "viem";
+
+const requestBase = {
+  status: "vouching",
+  requestStatus: RequestStatus.VOUCHING,
+  funded: 10n,
+  totalCost: 40n,
+  validVouches: 1,
+  onChainVouches: [
+    "0x1111111111111111111111111111111111111111" as Address,
+  ],
+  offChainVouches: [],
+  evidenceList: [],
+  revocation: false,
+};
+
+const profileBase = {
+  winningStatus: "resolved",
+  hasPendingRevocation: false,
+};
+
+const buildContext = (
+  functionName: string,
+  overrides: Partial<WriteSuccessContext> = {},
+): WriteSuccessContext => ({
+  contract: "ProofOfHumanity",
+  functionName,
+  args: [],
+  value: 0n,
+  chainId: 100,
+  txHash: "0x1234" as `0x${string}`,
+  ...overrides,
+});
+
+function RequestHarness() {
+  const requestOptimistic = useRequestOptimistic();
+
+  const api = useMemo(
+    (): OptimisticApi => ({
+      request: {
+        state: requestOptimistic.effective,
+        applyPatch: requestOptimistic.applyPatch,
+        address: "0x2222222222222222222222222222222222222222" as Address,
+      },
+    }),
+    [requestOptimistic],
+  );
+
+  return (
+    <section className="space-y-4 rounded border p-4" data-testid="request-panel">
+      <h2 className="text-xl font-semibold">Request Harness</h2>
+      <div className="flex flex-wrap gap-2">
+        <button
+          data-testid="fund-request"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              buildContext("fundRequest", {
+                args: ["0x01", 0n],
+                value: 15n,
+              }),
+              api,
+            )
+          }
+        >
+          Fund +15
+        </button>
+        <button
+          data-testid="add-vouch"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              buildContext("addVouch", {
+                args: ["0x01", "0x02"],
+              }),
+              api,
+            )
+          }
+        >
+          Add Vouch
+        </button>
+        <button
+          data-testid="advance-request"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(buildContext("advanceState"), api)
+          }
+        >
+          Advance
+        </button>
+        <button
+          data-testid="submit-evidence"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              buildContext("submitEvidence", {
+                args: ["0x01", 0n, "ipfs://optimistic-evidence"],
+              }),
+              api,
+            )
+          }
+        >
+          Submit Evidence
+        </button>
+        <button
+          data-testid="challenge-request"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(buildContext("challengeRequest"), api)
+          }
+        >
+          Challenge
+        </button>
+        <button
+          data-testid="clear-request"
+          className="rounded border px-3 py-2"
+          onClick={requestOptimistic.clearOverlay}
+        >
+          Clear
+        </button>
+      </div>
+      <dl className="grid grid-cols-2 gap-2 text-sm">
+        <dt>Status</dt>
+        <dd data-testid="request-status">{requestOptimistic.effective.status}</dd>
+        <dt>Request Status</dt>
+        <dd data-testid="request-request-status">
+          {requestOptimistic.effective.requestStatus}
+        </dd>
+        <dt>Funded</dt>
+        <dd data-testid="request-funded">
+          {requestOptimistic.effective.funded.toString()}
+        </dd>
+        <dt>Valid Vouches</dt>
+        <dd data-testid="request-vouches">
+          {requestOptimistic.effective.validVouches}
+        </dd>
+        <dt>Evidence Count</dt>
+        <dd data-testid="request-evidence-count">
+          {requestOptimistic.effective.evidenceList.length}
+        </dd>
+        <dt>Pending Challenge</dt>
+        <dd data-testid="request-pending-challenge">
+          {requestOptimistic.effective.pendingChallenge ? "yes" : "no"}
+        </dd>
+      </dl>
+    </section>
+  );
+}
+
+function ProfileHarness() {
+  const profileOptimistic = useProfileOptimistic();
+
+  const api = useMemo(
+    (): OptimisticApi => ({
+      profile: {
+        state: profileOptimistic.effective,
+        applyPatch: profileOptimistic.applyPatch,
+      },
+    }),
+    [profileOptimistic],
+  );
+
+  return (
+    <section className="space-y-4 rounded border p-4" data-testid="profile-panel">
+      <h2 className="text-xl font-semibold">Profile Harness</h2>
+      <div className="flex flex-wrap gap-2">
+        <button
+          data-testid="revoke-humanity"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(buildContext("revokeHumanity"), api)
+          }
+        >
+          Revoke
+        </button>
+        <button
+          data-testid="transfer-humanity"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              {
+                ...buildContext("transferHumanity"),
+                contract: "CrossChainProofOfHumanity",
+              },
+              api,
+            )
+          }
+        >
+          Transfer
+        </button>
+        <button
+          data-testid="update-humanity"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              {
+                ...buildContext("updateHumanity"),
+                contract: "CrossChainProofOfHumanity",
+              },
+              api,
+            )
+          }
+        >
+          Update
+        </button>
+        <button
+          data-testid="execute-signatures"
+          className="rounded border px-3 py-2"
+          onClick={() =>
+            applyOptimisticWriteSuccess(
+              {
+                ...buildContext("executeSignatures"),
+                contract: "EthereumAMBBridge",
+              },
+              api,
+            )
+          }
+        >
+          Execute Signatures
+        </button>
+        <button
+          data-testid="clear-profile"
+          className="rounded border px-3 py-2"
+          onClick={profileOptimistic.clearOverlay}
+        >
+          Clear
+        </button>
+      </div>
+      <dl className="grid grid-cols-2 gap-2 text-sm">
+        <dt>Winning Status</dt>
+        <dd data-testid="profile-winning-status">
+          {profileOptimistic.effective.winningStatus ?? "none"}
+        </dd>
+        <dt>Pending Revocation</dt>
+        <dd data-testid="profile-pending-revocation">
+          {profileOptimistic.effective.pendingRevocation ? "yes" : "no"}
+        </dd>
+        <dt>Pending Transfer</dt>
+        <dd data-testid="profile-pending-transfer">
+          {profileOptimistic.effective.pendingTransfer ? "yes" : "no"}
+        </dd>
+        <dt>Pending Update</dt>
+        <dd data-testid="profile-pending-update">
+          {profileOptimistic.effective.pendingUpdate ? "yes" : "no"}
+        </dd>
+      </dl>
+    </section>
+  );
+}
+
+export default function OptimisticDebugPage() {
+  return (
+    <main className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+      <h1 className="text-2xl font-bold">Optimistic Write Debug</h1>
+      <p className="text-sm text-slate-600">
+        This route exercises the real optimistic helper and providers without a
+        wallet dependency.
+      </p>
+      <RequestOptimisticProvider base={requestBase}>
+        <RequestHarness />
+      </RequestOptimisticProvider>
+      <ProfileOptimisticProvider base={profileBase}>
+        <ProfileHarness />
+      </ProfileOptimisticProvider>
+    </main>
+  );
+}

--- a/src/contracts/hooks/types.ts
+++ b/src/contracts/hooks/types.ts
@@ -1,8 +1,10 @@
 import { ContractName, contractRegistry } from "contracts";
 import {
   ContractFunctionArgs,
+  Hash,
   ReadContractParameters,
   ReadContractReturnType,
+  TransactionReceipt,
   WriteContractParameters,
 } from "viem";
 
@@ -28,11 +30,21 @@ export type WriteArgs<
   F extends WriteFunctionName<C>,
 > = ContractFunctionArgs<ContractAbi<C>, "nonpayable" | "payable", F>;
 
+export interface WriteSuccessContext {
+  contract: ContractName;
+  functionName: string;
+  args?: readonly unknown[];
+  value?: bigint;
+  chainId: number;
+  txHash?: Hash;
+  receipt?: TransactionReceipt;
+}
+
 export interface Effects {
   onLoading?: () => void;
   onError?: (error?: unknown) => void;
   onFail?: (error?: unknown) => void;
-  onSuccess?: () => void;
+  onSuccess?: (ctx: WriteSuccessContext) => void;
   onReady?: (fire: () => void) => void;
 }
 

--- a/src/contracts/hooks/useWagmiWrite.ts
+++ b/src/contracts/hooks/useWagmiWrite.ts
@@ -1,5 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
-import { WriteArgs, WriteFunctionName, Effects } from "./types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  WriteArgs,
+  WriteFunctionName,
+  Effects,
+  WriteSuccessContext,
+} from "./types";
 import { SupportedChainId } from "config/chains";
 import {
   useChainId,
@@ -55,15 +60,32 @@ export default function useWagmiWrite<
   } as any);
 
   const { writeContract, data, status, error: writeError } = useWriteContract();
-  const { status: transactionStatus } = useWaitForTransactionReceipt({
+  const { data: receipt, status: transactionStatus } = useWaitForTransactionReceipt({
     hash: data,
   });
+  const lastWriteRef = useRef<{
+    args?: readonly unknown[];
+    value?: bigint;
+    chainId: number;
+  } | null>(null);
+
+  const fireWrite = useCallback(
+    (request: any) => {
+      lastWriteRef.current = {
+        args: args as readonly unknown[] | undefined,
+        value,
+        chainId: chain?.id || defaultChainId,
+      };
+      writeContract(request);
+    },
+    [args, value, chain?.id, defaultChainId, writeContract],
+  );
 
   useEffect(() => {
     switch (prepareStatus) {
       case "success":
         if (prepared.request && enabled) {
-          effects?.onReady?.(() => writeContract(prepared.request));
+          effects?.onReady?.(() => fireWrite(prepared.request));
           setEnabled(false);
         }
         break;
@@ -73,16 +95,16 @@ export default function useWagmiWrite<
           setEnabled(false);
         }
     }
-  }, [prepareStatus, effects, enabled, prepared?.request, writeContract]);
+  }, [prepareStatus, effects, enabled, prepared?.request, fireWrite]);
 
   useEffect(() => {
     switch (status) {
       case "error":
         console.log(writeError);
-        effects?.onError?.();
+        effects?.onError?.(writeError);
         setEnabled(false);
     }
-  }, [status, effects]);
+  }, [status, effects, writeError]);
 
   useEffect(() => {
     if (data) {
@@ -90,11 +112,31 @@ export default function useWagmiWrite<
         case "pending":
           effects?.onLoading?.();
           break;
-        case "success":
-          effects?.onSuccess?.();
+        case "success": {
+          const ctx: WriteSuccessContext = {
+            contract,
+            functionName: String(functionName),
+            args: lastWriteRef.current?.args,
+            value: lastWriteRef.current?.value,
+            chainId: lastWriteRef.current?.chainId ?? (chain?.id || defaultChainId),
+            txHash: data,
+            receipt,
+          };
+          effects?.onSuccess?.(ctx);
+          break;
+        }
       }
     }
-  }, [transactionStatus, effects]);
+  }, [
+    transactionStatus,
+    effects,
+    data,
+    receipt,
+    contract,
+    functionName,
+    chain?.id,
+    defaultChainId,
+  ]);
 
   return useMemo(
     () =>
@@ -106,7 +148,7 @@ export default function useWagmiWrite<
         },
         () => {
           if (prepared?.request)
-            writeContract(prepared.request);
+            fireWrite(prepared.request);
           setEnabled(false);
         },
         {
@@ -115,6 +157,6 @@ export default function useWagmiWrite<
           transaction: transactionStatus,
         },
       ] as const,
-    [prepareStatus, status, transactionStatus, prepared?.request, writeContract],
+    [prepareStatus, status, transactionStatus, prepared?.request, fireWrite],
   );
 }

--- a/src/optimistic/applyOptimisticWriteSuccess.ts
+++ b/src/optimistic/applyOptimisticWriteSuccess.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { getContractInfo } from "contracts";
+import type { WriteSuccessContext } from "contracts/hooks/types";
+import { decodeEventLog, type Address } from "viem";
+import { RequestStatus } from "utils/status";
+import type {
+  ProfileOptimisticBase,
+  ProfileOptimisticOverlay,
+  RequestOptimisticBase,
+  RequestOptimisticOverlay,
+} from "./types";
+
+export interface OptimisticApi {
+  request?: {
+    state: RequestOptimisticBase;
+    applyPatch: (patch: RequestOptimisticOverlay) => void;
+    address?: Address;
+  };
+  profile?: {
+    state: ProfileOptimisticBase & {
+      pendingRevocation?: boolean;
+      pendingTransfer?: boolean;
+      pendingUpdate?: boolean;
+    };
+    applyPatch: (patch: ProfileOptimisticOverlay) => void;
+  };
+}
+
+const getChallengeDisputeId = (ctx: WriteSuccessContext) => {
+  if (!ctx.receipt || ctx.contract !== "ProofOfHumanity") return undefined;
+
+  const abi = getContractInfo("ProofOfHumanity", ctx.chainId).abi;
+
+  for (const log of ctx.receipt.logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "RequestChallenged") {
+        return String((decoded.args as { disputeId?: bigint }).disputeId ?? "");
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+};
+
+export function applyOptimisticWriteSuccess(
+  ctx: WriteSuccessContext,
+  api: OptimisticApi,
+) {
+  const requestState = api.request?.state;
+  const address = api.request?.address;
+
+  switch (`${ctx.contract}:${ctx.functionName}`) {
+    case "ProofOfHumanity:advanceState":
+      if (!requestState || !api.request) return;
+      api.request.applyPatch({
+        status: "resolving",
+        requestStatus: RequestStatus.PENDING_CLAIM,
+      });
+      return;
+
+    case "ProofOfHumanity:executeRequest":
+      if (!requestState || !api.request) return;
+      api.request.applyPatch({
+        status: "resolved",
+        requestStatus: requestState.revocation
+          ? RequestStatus.RESOLVED_REVOCATION
+          : RequestStatus.RESOLVED_CLAIM,
+      });
+      return;
+
+    case "ProofOfHumanity:withdrawRequest":
+      if (!api.request) return;
+      api.request.applyPatch({
+        status: "withdrawn",
+        requestStatus: RequestStatus.WITHDRAWN,
+      });
+      return;
+
+    case "ProofOfHumanity:fundRequest":
+      if (!requestState || !api.request) return;
+      api.request.applyPatch({
+        funded: requestState.funded + (ctx.value ?? 0n) > requestState.totalCost
+          ? requestState.totalCost
+          : requestState.funded + (ctx.value ?? 0n),
+      });
+      return;
+
+    case "ProofOfHumanity:addVouch":
+      if (!requestState || !api.request || !address) return;
+      if (
+        requestState.onChainVouches.some(
+          (vouchAddress) => vouchAddress.toLowerCase() === address.toLowerCase(),
+        )
+      )
+        return;
+      api.request.applyPatch({
+        onChainVouches: [...requestState.onChainVouches, address],
+        validVouches: requestState.validVouches + 1,
+      });
+      return;
+
+    case "ProofOfHumanity:removeVouch":
+      if (!requestState || !api.request || !address) return;
+      api.request.applyPatch({
+        onChainVouches: requestState.onChainVouches.filter(
+          (vouchAddress) => vouchAddress.toLowerCase() !== address.toLowerCase(),
+        ),
+        validVouches: Math.max(0, requestState.validVouches - 1),
+      });
+      return;
+
+    case "ProofOfHumanity:submitEvidence":
+      if (!api.request || !address) return;
+      if (!ctx.args?.[2] || typeof ctx.args[2] !== "string") return;
+      api.request.applyPatch({
+        appendedEvidence: [
+          {
+            id: `optimistic-evidence-${ctx.txHash ?? Date.now()}`,
+            uri: ctx.args[2],
+            creationTime: Math.floor(Date.now() / 1000),
+            submitter: address,
+            pending: true,
+          },
+        ],
+      });
+      return;
+
+    case "ProofOfHumanity:challengeRequest":
+      if (!requestState || !api.request) return;
+      api.request.applyPatch({
+        status: "disputed",
+        requestStatus: requestState.revocation
+          ? RequestStatus.DISPUTED_REVOCATION
+          : RequestStatus.DISPUTED_CLAIM,
+        pendingChallenge: {
+          disputeId: getChallengeDisputeId(ctx),
+          createdAt: Date.now(),
+        },
+      });
+      return;
+
+    case "ProofOfHumanity:revokeHumanity":
+      if (!api.profile) return;
+      api.profile.applyPatch({ pendingRevocation: true });
+      return;
+
+    case "CrossChainProofOfHumanity:transferHumanity":
+      if (!api.profile) return;
+      api.profile.applyPatch({ pendingTransfer: true });
+      return;
+
+    case "CrossChainProofOfHumanity:updateHumanity":
+    case "EthereumAMBBridge:executeSignatures":
+      if (!api.profile) return;
+      api.profile.applyPatch({ pendingUpdate: true });
+      return;
+
+    case "ProofOfHumanity:claimHumanity":
+    case "ProofOfHumanity:renewHumanity":
+    case "ProofOfHumanity:fundAppeal":
+      return;
+
+    default:
+      return;
+  }
+}

--- a/src/optimistic/profile.tsx
+++ b/src/optimistic/profile.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { ProfileOptimisticBase, ProfileOptimisticOverlay } from "./types";
+
+const OVERLAY_TTL_MS = 5 * 60 * 1000;
+
+interface ProfileOptimisticContextValue {
+  base: ProfileOptimisticBase;
+  effective: ProfileOptimisticBase & {
+    pendingRevocation: boolean;
+    pendingTransfer: boolean;
+    pendingUpdate: boolean;
+  };
+  applyPatch: (patch: ProfileOptimisticOverlay) => void;
+  clearOverlay: () => void;
+}
+
+const ProfileOptimisticContext =
+  createContext<ProfileOptimisticContextValue | null>(null);
+
+const reconcileOverlay = (
+  base: ProfileOptimisticBase,
+  overlay: ProfileOptimisticOverlay | null,
+) => {
+  if (!overlay) return null;
+  const next = { ...overlay };
+
+  if (base.hasPendingRevocation) delete next.pendingRevocation;
+  if (base.winningStatus === "transferring" || base.winningStatus === "transferred")
+    delete next.pendingTransfer;
+
+  if (
+    next.pendingRevocation === undefined &&
+    next.pendingTransfer === undefined &&
+    next.pendingUpdate === undefined
+  ) {
+    return null;
+  }
+
+  return next;
+};
+
+export function ProfileOptimisticProvider({
+  base,
+  children,
+}: {
+  base: ProfileOptimisticBase;
+  children: ReactNode;
+}) {
+  const [overlay, setOverlay] = useState<ProfileOptimisticOverlay | null>(null);
+
+  useEffect(() => {
+    setOverlay((current) => reconcileOverlay(base, current));
+  }, [base]);
+
+  useEffect(() => {
+    if (!overlay) return;
+    const timeoutId = window.setTimeout(() => {
+      setOverlay(null);
+    }, OVERLAY_TTL_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [overlay]);
+
+  const applyPatch = useCallback((patch: ProfileOptimisticOverlay) => {
+    setOverlay((current) => ({
+      ...current,
+      ...patch,
+    }));
+  }, []);
+
+  const clearOverlay = useCallback(() => {
+    setOverlay(null);
+  }, []);
+
+  const effective = useMemo(
+    () => ({
+      ...base,
+      winningStatus: overlay?.pendingTransfer ? "transferring" : base.winningStatus,
+      pendingRevocation: overlay?.pendingRevocation ?? false,
+      pendingTransfer: overlay?.pendingTransfer ?? false,
+      pendingUpdate: overlay?.pendingUpdate ?? false,
+    }),
+    [base, overlay],
+  );
+
+  const value = useMemo(
+    () => ({
+      base,
+      effective,
+      applyPatch,
+      clearOverlay,
+    }),
+    [base, effective, applyPatch, clearOverlay],
+  );
+
+  return (
+    <ProfileOptimisticContext.Provider value={value}>
+      {children}
+    </ProfileOptimisticContext.Provider>
+  );
+}
+
+export function useProfileOptimistic() {
+  const context = useContext(ProfileOptimisticContext);
+  if (!context) {
+    throw new Error("useProfileOptimistic must be used within ProfileOptimisticProvider");
+  }
+  return context;
+}

--- a/src/optimistic/request.tsx
+++ b/src/optimistic/request.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type {
+  OptimisticEvidenceItem,
+  RequestOptimisticBase,
+  RequestOptimisticOverlay,
+} from "./types";
+
+const OVERLAY_TTL_MS = 2 * 60 * 1000;
+
+interface RequestOptimisticContextValue {
+  base: RequestOptimisticBase;
+  effective: RequestOptimisticBase & {
+    pendingChallenge?: RequestOptimisticOverlay["pendingChallenge"];
+  };
+  applyPatch: (patch: RequestOptimisticOverlay) => void;
+  clearOverlay: () => void;
+}
+
+const RequestOptimisticContext =
+  createContext<RequestOptimisticContextValue | null>(null);
+
+const dedupeEvidence = (items: OptimisticEvidenceItem[]) => {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = item.uri;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const mergeEvidence = (
+  base: OptimisticEvidenceItem[],
+  appended?: OptimisticEvidenceItem[],
+) =>
+  dedupeEvidence([...(base ?? []), ...(appended ?? [])]).sort(
+    (left, right) => left.creationTime - right.creationTime,
+  );
+
+const reconcileOverlay = (
+  base: RequestOptimisticBase,
+  overlay: RequestOptimisticOverlay | null,
+) => {
+  if (!overlay) return null;
+
+  const next: RequestOptimisticOverlay = { ...overlay };
+
+  if (next.status === base.status) delete next.status;
+  if (next.requestStatus === base.requestStatus) delete next.requestStatus;
+  if (typeof next.funded === "bigint" && base.funded >= next.funded)
+    delete next.funded;
+  if (
+    typeof next.validVouches === "number" &&
+    base.validVouches === next.validVouches
+  )
+    delete next.validVouches;
+
+  if (next.onChainVouches) {
+    const baseSet = new Set(base.onChainVouches.map((item) => item.toLowerCase()));
+    const matches = next.onChainVouches.every((item) =>
+      baseSet.has(item.toLowerCase()),
+    );
+    if (matches) delete next.onChainVouches;
+  }
+
+  if (next.offChainVouches) {
+    const baseSet = new Set(
+      base.offChainVouches.map((item) => item.voucher.toLowerCase()),
+    );
+    const matches = next.offChainVouches.every((item) =>
+      baseSet.has(item.voucher.toLowerCase()),
+    );
+    if (matches) delete next.offChainVouches;
+  }
+
+  if (next.appendedEvidence) {
+    const baseUris = new Set(base.evidenceList.map((item) => item.uri));
+    const allPresent = next.appendedEvidence.every((item) =>
+      baseUris.has(item.uri),
+    );
+    if (allPresent) delete next.appendedEvidence;
+  }
+
+  if (next.pendingChallenge && (base.status === "disputed" || base.currentChallengeDisputeId))
+    delete next.pendingChallenge;
+
+  if (
+    next.status === undefined &&
+    next.requestStatus === undefined &&
+    next.funded === undefined &&
+    next.validVouches === undefined &&
+    next.onChainVouches === undefined &&
+    next.offChainVouches === undefined &&
+    next.appendedEvidence === undefined &&
+    next.pendingChallenge === undefined
+  ) {
+    return null;
+  }
+
+  return next;
+};
+
+export function RequestOptimisticProvider({
+  base,
+  children,
+}: {
+  base: RequestOptimisticBase;
+  children: ReactNode;
+}) {
+  const [overlay, setOverlay] = useState<RequestOptimisticOverlay | null>(null);
+
+  useEffect(() => {
+    setOverlay((current) => reconcileOverlay(base, current));
+  }, [base]);
+
+  useEffect(() => {
+    if (!overlay) return;
+    const timeoutId = window.setTimeout(() => {
+      setOverlay(null);
+    }, OVERLAY_TTL_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [overlay]);
+
+  const applyPatch = useCallback((patch: RequestOptimisticOverlay) => {
+    setOverlay((current) => ({
+      ...current,
+      ...patch,
+      appendedEvidence:
+        patch.appendedEvidence || current?.appendedEvidence
+          ? mergeEvidence(
+              current?.appendedEvidence ?? [],
+              patch.appendedEvidence,
+            )
+          : undefined,
+    }));
+  }, []);
+
+  const clearOverlay = useCallback(() => {
+    setOverlay(null);
+  }, []);
+
+  const effective = useMemo(
+    () => ({
+      ...base,
+      status: overlay?.status ?? base.status,
+      requestStatus: overlay?.requestStatus ?? base.requestStatus,
+      funded: overlay?.funded ?? base.funded,
+      validVouches: overlay?.validVouches ?? base.validVouches,
+      onChainVouches: overlay?.onChainVouches ?? base.onChainVouches,
+      offChainVouches: overlay?.offChainVouches ?? base.offChainVouches,
+      evidenceList: mergeEvidence(base.evidenceList, overlay?.appendedEvidence),
+      pendingChallenge: overlay?.pendingChallenge,
+    }),
+    [base, overlay],
+  );
+
+  const value = useMemo(
+    () => ({
+      base,
+      effective,
+      applyPatch,
+      clearOverlay,
+    }),
+    [base, effective, applyPatch, clearOverlay],
+  );
+
+  return (
+    <RequestOptimisticContext.Provider value={value}>
+      {children}
+    </RequestOptimisticContext.Provider>
+  );
+}
+
+export function useRequestOptimistic() {
+  const context = useContext(RequestOptimisticContext);
+  if (!context) {
+    throw new Error("useRequestOptimistic must be used within RequestOptimisticProvider");
+  }
+  return context;
+}

--- a/src/optimistic/types.ts
+++ b/src/optimistic/types.ts
@@ -1,0 +1,48 @@
+import { Address, Hash } from "viem";
+import { RequestStatus } from "utils/status";
+
+export interface OptimisticEvidenceItem {
+  id: string;
+  uri: string;
+  creationTime: number;
+  submitter: Address;
+  pending?: boolean;
+}
+
+export interface RequestOptimisticBase {
+  status: string;
+  requestStatus: RequestStatus;
+  funded: bigint;
+  totalCost: bigint;
+  validVouches: number;
+  onChainVouches: Address[];
+  offChainVouches: { voucher: Address; expiration: number; signature: Hash }[];
+  evidenceList: OptimisticEvidenceItem[];
+  revocation: boolean;
+  currentChallengeDisputeId?: string;
+}
+
+export interface RequestOptimisticOverlay {
+  status?: string;
+  requestStatus?: RequestStatus;
+  funded?: bigint;
+  validVouches?: number;
+  onChainVouches?: Address[];
+  offChainVouches?: { voucher: Address; expiration: number; signature: Hash }[];
+  appendedEvidence?: OptimisticEvidenceItem[];
+  pendingChallenge?: {
+    disputeId?: string;
+    createdAt: number;
+  };
+}
+
+export interface ProfileOptimisticBase {
+  winningStatus?: string;
+  hasPendingRevocation: boolean;
+}
+
+export interface ProfileOptimisticOverlay {
+  pendingRevocation?: boolean;
+  pendingTransfer?: boolean;
+  pendingUpdate?: boolean;
+}

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -97,7 +97,11 @@ const STATUS_CONFIG: Record<RequestStatus, StatusConfig> = {
     baseLabel: "Removed",
     tooltip: "Profile removed after due process.",
     color: STATUS_COLORS.removed,
-    filter: { status: "resolved", revocation: true }
+    filter: {
+      status: "resolved",
+      revocation: true,
+      winnerParty_: { id: "requester" }
+    }
   },
   [RequestStatus.REJECTED]: {
     baseLabel: "Rejected",
@@ -178,7 +182,8 @@ const getRequestStatus = (
   status: string,
   revocation: boolean = false,
   expired: boolean = false,
-  rejected: boolean = false
+  rejected: boolean = false,
+  winnerPartyId?: string | null,
 ): RequestStatus => {
   switch (status) {
     case "vouching":
@@ -192,7 +197,11 @@ const getRequestStatus = (
     
     case "resolved":
       if (revocation) {
-        return RequestStatus.RESOLVED_REVOCATION;
+        return winnerPartyId === "requester"
+          ? RequestStatus.RESOLVED_REVOCATION
+          : expired
+            ? RequestStatus.EXPIRED
+            : RequestStatus.RESOLVED_CLAIM;
       }
       if (expired) {
         return RequestStatus.EXPIRED;
@@ -253,6 +262,7 @@ export const getStatus = (
     request.revocation,
     expired,
     rejected,
+    request.winnerParty?.id,
   );
 };
 


### PR DESCRIPTION
Summary:
- Stop treating revoked humanity as an accepted request by correcting status checks used across Request pages, action bars, and claim/revoke flows
- Align Wagmi write hooks, status utils, and optimistic state helpers so approvals and rewards aren’t shown when revocation has occurred
- Add optimistic helpers and a debug page for visualizing request/profile state changes, ensuring the UI mirrors contract state more reliably

Testing:
- Not run (not requested)