### PR TITLE
Fix off-chain vouch signature parsing in advanceState preparation

### DIFF
--- a/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
+++ b/src/app/[pohid]/[chain]/[request]/ActionBar.tsx
@@ -34,6 +34,16 @@ enableReactUse();
 //     args: [claimer, vouchers, []],
 //   });
 
+const toOffChainContractSignature = (signature: Hash) => {
+  const parsed = hexToSignature(signature);
+
+  return {
+    v: parsed.yParity + 27,
+    r: parsed.r,
+    s: parsed.s,
+  };
+};
+
 interface ActionBarProps {
   pohId: Hash;
   arbitrationCost: bigint;
@@ -207,12 +217,9 @@ export default function ActionBar({
           requester,
           onChainVouches,
           offChainVouches.map((v) => {
-            const sig = hexToSignature(v.signature);
             return {
+              ...toOffChainContractSignature(v.signature),
               expirationTime: v.expiration,
-              v: Number(sig.v),
-              r: sig.r,
-              s: sig.s,
             };
           }),
         ],


### PR DESCRIPTION
## Summary
- convert off-chain vouch signatures from `hexToSignature` using `yParity + 27` instead of `sig.v`
- add a small helper to build the contract-ready signature tuple before preparing `advanceState`
- prevent `advanceState` preparation from failing for requests that rely on off-chain vouches

## Testing
- Not run (not requested)