### PR TITLE
Fix pending evidence order in request page

### DIFF
--- a/src/app/[pohid]/[chain]/[request]/Evidence.tsx
+++ b/src/app/[pohid]/[chain]/[request]/Evidence.tsx
@@ -94,7 +94,11 @@ function Item({ index, item, isPending }: ItemInterface) {
   const description = evidence?.description || item.description;
 
   return (
-    <div className={`mt-4 flex flex-col${isPending ? "opacity-70" : ""}`}>
+    <div
+      className={
+        isPending ? "mt-4 flex flex-col opacity-70" : "mt-4 flex flex-col"
+      }
+    >
       <div className="paper relative px-8 py-4">
         <span className="absolute left-3 text-sm text-slate-500">
           {romanize(index + 1)}
@@ -370,17 +374,22 @@ export default function Evidence({
         </>
       )}
 
-      {effective.evidenceList.map((item, i) => (
-        <Item key={item.id} index={i} item={item} isPending={false} />
-      ))}
       {pendingAction === "evidence" && pendingEvidenceItem && (
         <Item
           key={pendingEvidenceItem.id}
-          index={effective.evidenceList.length}
+          index={0}
           item={pendingEvidenceItem}
           isPending
         />
       )}
+      {effective.evidenceList.map((item, i) => (
+        <Item
+          key={item.id}
+          index={pendingEvidenceItem ? i + 1 : i}
+          item={item}
+          isPending={false}
+        />
+      ))}
     </Accordion>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual distinction for pending evidence items with updated styling.
  * Reordered evidence items to display pending actions first in the list with corrected numbering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Proof-Of-Humanity/proof-of-humanity-v2-web/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->