### PR TITLE
Add redirect for v2.poh.id to canonical Proof of Humanity domain

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,5 @@
+# Temporary PR 423 preview redirect for testing this Netlify rule.
+https://deploy-preview-423--proof-of-humanity-v2.netlify.app/* https://v2.poh.id/:splat 302!
+
 # Redirect v2.poh.id to the canonical Proof of Humanity domain.
 https://v2.poh.id/* https://proofofhumanity.id/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,2 @@
-# Temporary PR 423 preview redirect for testing this Netlify rule.
-https://deploy-preview-423--proof-of-humanity-v2.netlify.app/* https://v2.poh.id/:splat 302!
-
 # Redirect v2.poh.id to the canonical Proof of Humanity domain.
 https://v2.poh.id/* https://proofofhumanity.id/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Redirect v2.poh.id to the canonical Proof of Humanity domain.
+https://v2.poh.id/* https://proofofhumanity.id/:splat 301!


### PR DESCRIPTION
- Created a new _redirects file to permanently redirect traffic from v2.poh.id to proofofhumanity.id, ensuring users reach the correct domain.
- Implemented a 301 redirect for improved SEO and user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured permanent redirect from v2.poh.id to proofofhumanity.id

<!-- end of auto-generated comment: release notes by coderabbit.ai -->