### PR TITLE
Add important notice regarding PNK unstaking in Airdrop content

### DIFF
--- a/src/components/Integrations/Airdrop/PnkAirdropContent.tsx
+++ b/src/components/Integrations/Airdrop/PnkAirdropContent.tsx
@@ -147,6 +147,12 @@ export default function PnkAirdropContent({
                     potential rewards.
                   </p>
 
+                  <div className="text-secondaryText border-orange border-l-2 pl-2 text-xs leading-relaxed">
+                    <strong className="text-orange">Important:</strong>{" "}
+                    Unstaking your PNK immediately after the airdrop may make you
+                    ineligible for other Proof of Humanity rewards.
+                  </div>
+
                   <div className="text-secondaryText border-purple border-l-2 pl-2 text-xs">
                     <strong>Note:</strong> Your staked PNK is locked and may be
                     used to vote in disputes. Missing voting deadlines may


### PR DESCRIPTION
- Included a warning about the potential ineligibility for Proof of Humanity rewards if PNK is unstaked immediately after the airdrop.
- Enhanced user awareness of the implications of their actions related to the airdrop process.