### PR TITLE
Fix/ifps upload cache

### DIFF
--- a/src/app/[pohid]/claim/Form.tsx
+++ b/src/app/[pohid]/claim/Form.tsx
@@ -66,6 +66,11 @@ export interface MediaState {
   video: { uri: string; content: Blob } | null;
 }
 
+type UploadedMediaCache = {
+  content: Blob;
+  uri: string;
+};
+
 export interface SubmissionState {
   pohId: Hash;
   name: string;
@@ -151,6 +156,12 @@ function FormContent({
   const [emailStatus, setEmailStatus] = useState<EmailSubmissionStatus>("idle");
   const stepHistoryReady = useRef(false);
   const previousStepRef = useRef(Step.info);
+  const uploadedMediaRef = useRef<
+    Record<keyof MediaState, UploadedMediaCache | null>
+  >({
+    photo: null,
+    video: null,
+  });
   const canGoBack =
     step > Step.info &&
     step < Step.finalized &&
@@ -247,6 +258,25 @@ function FormContent({
     syncedFundingChainId.current = chainId;
   }, [chainId, currentTotalCost, selfFunded$, submitForFree]);
 
+  const getUploadedMediaUri = async (
+    type: keyof MediaState,
+    mediaItem: NonNullable<MediaState[keyof MediaState]>,
+    role: Roles,
+  ) => {
+    const cached = uploadedMediaRef.current[type];
+    if (cached?.content === mediaItem.content) return cached.uri;
+
+    const uri = await uploadToIPFS(mediaItem.content as File, role);
+    if (uri) {
+      uploadedMediaRef.current[type] = {
+        content: mediaItem.content,
+        uri,
+      };
+    }
+
+    return uri;
+  };
+
   const submit = async () => {
     if (!media.photo || !media.video) return;
     if (!currentTotalCost) {
@@ -257,12 +287,9 @@ function FormContent({
     state$.uri.set("");
     loading.start("Uploading media");
     try {
-      const photoFile = media.photo.content as File;
-      const videoFile = media.video.content as File;
-
       const [photoUri, videoUri] = await Promise.all([
-        uploadToIPFS(photoFile, Roles.Photo),
-        uploadToIPFS(videoFile, Roles.IdentificationVideo),
+        getUploadedMediaUri("photo", media.photo, Roles.Photo),
+        getUploadedMediaUri("video", media.video, Roles.IdentificationVideo),
       ]);
 
       if (!photoUri || !videoUri) {

--- a/src/app/[pohid]/claim/Form.tsx
+++ b/src/app/[pohid]/claim/Form.tsx
@@ -66,11 +66,6 @@ export interface MediaState {
   video: { uri: string; content: Blob } | null;
 }
 
-type UploadedMediaCache = {
-  content: Blob;
-  uri: string;
-};
-
 export interface SubmissionState {
   pohId: Hash;
   name: string;
@@ -156,11 +151,16 @@ function FormContent({
   const [emailStatus, setEmailStatus] = useState<EmailSubmissionStatus>("idle");
   const stepHistoryReady = useRef(false);
   const previousStepRef = useRef(Step.info);
-  const uploadedMediaRef = useRef<
-    Record<keyof MediaState, UploadedMediaCache | null>
-  >({
+  const uploadCache = useRef<{
+    photo: { content: Blob; uri: string } | null;
+    video: { content: Blob; uri: string } | null;
+    file: { json: string; uri: string } | null;
+    registration: { fileURI: string; uri: string } | null;
+  }>({
     photo: null,
     video: null,
+    file: null,
+    registration: null,
   });
   const canGoBack =
     step > Step.info &&
@@ -263,12 +263,12 @@ function FormContent({
     mediaItem: NonNullable<MediaState[keyof MediaState]>,
     role: Roles,
   ) => {
-    const cached = uploadedMediaRef.current[type];
+    const cached = uploadCache.current[type];
     if (cached?.content === mediaItem.content) return cached.uri;
 
     const uri = await uploadToIPFS(mediaItem.content as File, role);
     if (uri) {
-      uploadedMediaRef.current[type] = {
+      uploadCache.current[type] = {
         content: mediaItem.content,
         uri,
       };
@@ -298,18 +298,19 @@ function FormContent({
         return;
       }
 
-      const fileJson = {
+      const fileJson = JSON.stringify({
         name: state.name,
         photo: photoUri,
         video: videoUri,
-      };
-
-      const fileTextFile = new File([JSON.stringify(fileJson)], "file", {
-        type: "text/plain",
       });
-
-      let fileURI: string | null;
-      fileURI = await uploadToIPFS(fileTextFile, Roles.Evidence);
+      let fileURI =
+        uploadCache.current.file?.json === fileJson
+          ? uploadCache.current.file.uri
+          : await uploadToIPFS(
+              new File([fileJson], "file", { type: "text/plain" }),
+              Roles.Evidence,
+            );
+      if (fileURI) uploadCache.current.file = { json: fileJson, uri: fileURI };
 
       if (!fileURI) {
         toast.error("Failed to upload media metadata.");
@@ -319,24 +320,25 @@ function FormContent({
 
       loading.start("Uploading evidence files");
 
-      const registrationJson = {
+      const registrationJson = JSON.stringify({
         name: "Registration",
         fileURI,
-      };
+      });
+      const registrationUri =
+        uploadCache.current.registration?.fileURI === fileURI
+          ? uploadCache.current.registration.uri
+          : await uploadToIPFS(
+              new File([registrationJson], "registration", {
+                type: "text/plain",
+              }),
+              Roles.Evidence,
+            );
+      if (registrationUri)
+        uploadCache.current.registration = {
+          fileURI,
+          uri: registrationUri,
+        };
 
-      const registrationTextFile = new File(
-        [JSON.stringify(registrationJson)],
-        "registration",
-        {
-          type: "text/plain",
-        },
-      );
-
-      let registrationUri: string | null;
-      registrationUri = await uploadToIPFS(
-        registrationTextFile,
-        Roles.Evidence,
-      );
       if (!registrationUri) {
         toast.error("Failed to upload registration.");
         loading.stop();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids re-uploading the same media and generated files during repeated submissions.
  * Reuses previously uploaded photo/video, evidence, and registration data when the inputs haven’t changed.
  * Keeps the final submission link updated after cached or new uploads complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->