### PR TITLE
fix(profile): show registration evidence in profile header/card

### DIFF
--- a/schemas/profileHumanity.gql
+++ b/schemas/profileHumanity.gql
@@ -37,7 +37,7 @@ query ProfileHumanity($id: ID!, $humanityId: Bytes!) {
       }
       punishedVouchTimestamp
       evidenceGroup {
-        evidence(orderBy: creationTime, orderDirection: desc, first: 1) {
+        evidence(orderBy: creationTime, orderDirection: asc, first: 1) {
           uri
         }
       }

--- a/schemas/profileRequest.gql
+++ b/schemas/profileRequest.gql
@@ -10,7 +10,7 @@ query ProfileRequest($id: ID!) {
       name
     }
     evidenceGroup {
-      evidence(orderBy: creationTime, orderDirection: desc, first: 1) {
+      evidence(orderBy: creationTime, orderDirection: asc, first: 1) {
         uri
       }
     }

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4080,7 +4080,7 @@ export const ProfileHumanityDocument = gql`
       }
       punishedVouchTimestamp
       evidenceGroup {
-        evidence(orderBy: creationTime, orderDirection: desc, first: 1) {
+        evidence(orderBy: creationTime, orderDirection: asc, first: 1) {
           uri
         }
       }
@@ -4118,7 +4118,7 @@ export const ProfileRequestDocument = gql`
       name
     }
     evidenceGroup {
-      evidence(orderBy: creationTime, orderDirection: desc, first: 1) {
+      evidence(orderBy: creationTime, orderDirection: asc, first: 1) {
         uri
       }
     }


### PR DESCRIPTION
ProfileHumanity and ProfileRequest queries fetched the newest evidence (orderDirection: desc, first: 1). For challenged/disputed profiles the newest evidence is the challenge justification, which has no fileURI, so the timeline header and profile card showed a blank avatar instead of the registration photo. Fetch the oldest evidence (asc) — the registration submission — matching winner.fragment and historicalWinnerClaim queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated evidence retrieval to consistently select the earliest available item based on creation time.
  * Applied the same ordering behavior across profile humanity and profile request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->