### PR TITLE
Update Gnosis Chain explorer URL for accuracy

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -24,7 +24,7 @@ const chainExplorers = [
   {
     id: 100,
     name: "Gnosis Chain",
-    explorer: "gnosisscan.io",
+    explorer: "gnosis.blockscout.com",
   },
   {
     id: 10200,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Gnosis Chain explorer links to use the Blockscout explorer, ensuring generated transaction and address links open at the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->